### PR TITLE
docs: make product-lab registry browseable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,39 +2,101 @@
 
 # Product Lab
 
-**A catalog of mature products.**
+**一个 repo 一行，直接浏览成熟产品。**
+
+[![Snapshot](https://img.shields.io/badge/snapshot-github--universe--2026--08--26-0969DA)](https://github.com/zinan92/park-operating-system)
+[![Products](https://img.shields.io/badge/products-37-2DA44E)](https://github.com/zinan92/product-lab)
 
 </div>
 
 ---
 
-One repo per row. Each product keeps its direct GitHub link, ownership/provenance, status and external lock metadata.
+```text
+in  mature product repos from owned + starred universe
+out one-row-per-repo product catalog + direct GitHub links + locked external refs
 
-This registry is generated from the canonical private registry at [zinan92/park-operating-system](https://github.com/zinan92/park-operating-system), snapshot `github-universe-2026-08-26`.
-
-## Contract
-
-| Field | Meaning |
-|---|---|
-| Primary home | This repo is the only primary home for each listed source repo |
-| Source | `owned` or `starred` provenance is preserved |
-| Lock | External repos point to a fixed commit SHA, not a live branch |
-| Private | Private source names and links may be visible, but access may return 404 |
-| History | Archived and removed entries remain auditable |
-
-## Contents
-
-- `snapshot.yaml` — generated scoped snapshot and export checksum
-- `entries/` — owned, starred and archived projections
-- `locks/` — external commit locks copied from Park OS
-- `tags.yaml` — approved tag vocabulary
-- `scripts/verify-scoped.sh` — generated-data verifier
-
-Run the verifier before changing or publishing this registry:
-
-```bash
-bash scripts/verify-scoped.sh
+fail product metadata sparse → review_status=needs_review
+fail private source inaccessible → keep link + mark PRIVATE
+fail multiple repos represent one product → keep one row per repo; do not aggregate
 ```
 
-The registry validates catalog integrity. It does not certify any listed product as production-ready.
+> Canonical source: [Park OS](https://github.com/zinan92/park-operating-system) · this repo is a generated scoped view.
+
+## At a glance
+
+| Scope | Count |
+|---|---:|
+| Owned products | 11 |
+| Starred products | 26 |
+| Total products | 37 |
+
+Product Lab is intentionally flat: there is no stage taxonomy here. A product name, one sentence and one direct link are the unit of navigation.
+
+## Owned products
+
+| Product | Capability | State | Source |
+|---|---|---|---|
+| [zinan92/codex-harness](https://github.com/zinan92/codex-harness) | 本地记录 Codex thread 的 token 使用与项目归属。in Codex session JSONL → out daily thread ledger + read-only HTML UI | `READY · —` | Owned |
+| [zinan92/life-kline](https://github.com/zinan92/life-kline) |  | `READY · PRIVATE` | Owned |
+| [zinan92/paileggemai](https://github.com/zinan92/paileggemai) | 电商商品图生成短视频工作台 | `READY · PRIVATE` | Owned |
+| [zinan92/park-builds](https://github.com/zinan92/park-builds) |  | `READY · —` | Owned |
+| [zinan92/proactive-explorer](https://github.com/zinan92/proactive-explorer) | Strategic product direction finder for open-source repos — 5 MECE categories: Product Depth, Product Reach, Time-to-Value, Trust & Proof, Growth | `READY · —` | Owned |
+| [zinan92/repo-evals](https://github.com/zinan92/repo-evals) | Claim-first repo 评测框架。in target repo + claim map → out bilingual verdict dossier + all-evals dashboard | `READY · —` | Owned |
+| [zinan92/tokenpulse](https://github.com/zinan92/tokenpulse) | 把 Claude/Codex 本地 token 日志变成桌面鞭策 widget、Telegram 推送、CLI 状态和可分享 QR 战绩卡。in 本地日志 + models.dev → out goad widget + share card | `EXPLORING · ARCHIVED` | Owned |
+| [zinan92/tokenrouter](https://github.com/zinan92/tokenrouter) | 个人项目组合工作台：双通道成本账本 + TokenRouter v0 级联内核 | `EXPLORING · ARCHIVED` | Owned |
+| [zinan92/wcstubhub-clone](https://github.com/zinan92/wcstubhub-clone) | 移动优先的票务市场平台 — FIFA 2026 主题，信任架构，智能定价，完整交易流程 | `EXPLORING · ARCHIVED` | Owned |
+| [zinan92/wechat-customer-pipeline](https://github.com/zinan92/wechat-customer-pipeline) | 把授权的本机微信数据库转成私有客户管道与关系行动快照。in WeChat 数据 + 迁移确认 → out HTML + CSV + A/B/C/D + actions + receipts | `READY · PRIVATE` | Owned |
+| [zinan92/wechat-xingqiu](https://github.com/zinan92/wechat-xingqiu) | wechat-xingqiu：原生微信会员内容小程序 | `READY · PRIVATE` | Owned |
+
+## Starred products
+
+| Product | Capability | State / Lock | Source |
+|---|---|---|---|
+| [6tail/tyme4ts](https://github.com/6tail/tyme4ts) | Tyme是一个非常强大的日历工具库，可以看作 Lunar 的升级版，拥有更优的设计和扩展性，支持公历、农历、藏历、回历、星座、干支、生肖、节气、月相、法定假日等。 | `READY · —` | Starred · lock 9e776099e164 |
+| [Brhiza/mingyu](https://github.com/Brhiza/mingyu) | 八字、紫微、星盘、六爻、梅花、奇门、大六壬、小六壬、塔罗、雷诺曼、灵签、择日一站式玄学算命占卜工具包，输出结构化提示词与数据。提供公开 API、MCP Server 与 skill。 | `READY · —` | Starred · lock 1272aa0cd83a |
+| [DestinyLinker/MingLi-Bench](https://github.com/DestinyLinker/MingLi-Bench) | A benchmark for evaluating LLMs on Chinese traditional fortune telling — Bazi (八字) and Ziwei Doushu (紫微斗数). | `READY · —` | Starred · lock b7433280fd86 |
+| [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) | Taste-Skill - gives your AI good taste. stops the AI from generating boring, generic slop  | `READY · —` | Starred · lock ccbc15639c97 |
+| [Renhuai123/ziwei-doushu](https://github.com/Renhuai123/ziwei-doushu) | 紫微斗数开源排盘引擎 — 基于倪海夏《天纪》体系，含完整排盘算法、四化系统、格局知识库、古籍原文数据 | `READY · —` | Starred · lock 88194a404242 |
+| [SylarLong/iztro](https://github.com/SylarLong/iztro) | ⭐This is a lightweight kit for generating astrolabes for Zi Wei Dou Shu (The Purple Star Astrology), an ancient Chinese astrology. It allows you to obtain your horoscope and personality analysis. 支持多语言轻量级获取紫微斗数排盘信息的javascript开源库。 | `READY · —` | Starred · lock 814b77e6371e |
+| [THU-MAIC/OpenMAIC](https://github.com/THU-MAIC/OpenMAIC) | Open Multi-Agent Interactive Classroom — Get an immersive, multi-agent learning experience in just one click | `READY · —` | Starred · lock 1b4a168175e8 |
+| [Usagi-org/ai-goofish-monitor](https://github.com/Usagi-org/ai-goofish-monitor) | 基于 Playwright 和AI实现的闲鱼多任务实时/定时监控与智能分析系统，配备了功能完善的后台管理UI。帮助用户从闲鱼海量商品中，找到心仪产品。 | `EXPLORING · ARCHIVED` | Starred · lock f85d140b6b45 |
+| [afumu/wetrace-skill](https://github.com/afumu/wetrace-skill) | 微信聊天记录skill | `READY · NEEDS_REVIEW` | Starred · lock 6280e9c106a2 |
+| [birobirobiro/awesome-shadcn-ui](https://github.com/birobirobiro/awesome-shadcn-ui) | A curated list of awesome things related to shadcn/ui. | `READY · —` | Starred · lock 7417bbeae2d2 |
+| [chenglou/pretext](https://github.com/chenglou/pretext) | Fast, accurate & comprehensive text measurement & layout | `READY · NEEDS_REVIEW` | Starred · lock ac49b09b7d83 |
+| [chenjin-cmd/wechat-miniprogram-builder](https://github.com/chenjin-cmd/wechat-miniprogram-builder) | wechat-miniprogram-builder | `READY · NEEDS_REVIEW` | Starred · lock e8bba7855d92 |
+| [chuspeeism/dashi-taskboard](https://github.com/chuspeeism/dashi-taskboard) |  | `READY · —` | Starred · lock f0f4cabced1b |
+| [curionox/lifekline](https://github.com/curionox/lifekline) | 人生K线 - 基于AI的八字命理可视化工具 | `READY · —` | Starred · lock b9a27a71260a |
+| [helloianneo/obsidian-ai-second-brain](https://github.com/helloianneo/obsidian-ai-second-brain) | Obsidian + Claude AI 个人知识库完整搭建指南 / 基于 Karpathy LLM Wiki 方法论 / 4 阶段 12 步 / 不用写代码 | `READY · —` | Starred · lock fb3468a1d5fa |
+| [idootop/open-xiaoai](https://github.com/idootop/open-xiaoai) | 🔊 让小爱音箱「听见你的声音」，解锁无限可能。  | `EXPLORING · ARCHIVED, NEEDS_REVIEW` | Starred · lock bc3396c64e2a |
+| [iptv-org/iptv](https://github.com/iptv-org/iptv) | Collection of publicly available IPTV channels from all over the world | `READY · —` | Starred · lock b0390e5c6a48 |
+| [learnwithu/mingli-master](https://github.com/learnwithu/mingli-master) | 紫微斗数命盘解读 skill · 基于 iztro-py 精确排盘，生成可视化命盘 HTML | `READY · —` | Starred · lock 000da99552cd |
+| [miounet11/life-kline](https://github.com/miounet11/life-kline) | 🌟 人生K线 - 基于 AI 大模型 + 传统八字命理的人生运势可视化工具。将命运绘制成 K 线图，像看股票一样看人生！支持自托管部署。 | `READY · —` | Starred · lock 7abf184df370 |
+| [n8n-io/n8n](https://github.com/n8n-io/n8n) | Fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations. | `READY · —` | Starred · lock 48c42fa4b8ca |
+| [nextlevelbuilder/ui-ux-pro-max-skill](https://github.com/nextlevelbuilder/ui-ux-pro-max-skill) | An AI skill that provides design intelligence for building professional UI/UX across multiple platforms. | `READY · —` | Starred · lock e353a508767c |
+| [nexu-io/html-anything](https://github.com/nexu-io/html-anything) | ✨ The agentic HTML editor — your local AI agent writes the HTML, you ship it. 🚀 75 Skills × 9 Surfaces (magazine · deck · poster · XHS / tweet · prototype · data report · Hyperframes) 🛡️ Sandboxed preview · 📤 1-click to WeChat / X / Zhihu / HTML / PNG 🔑 Zero API key — Claude Code / Cursor / Codex / Gemini / Copilot / OpenCode / Qwen / Aider. | `READY · —` | Starred · lock c31204544230 |
+| [nexu-io/open-design](https://github.com/nexu-io/open-design) | 🎨 Best DeepSeek Harness Design Plugin. The open-source Claude Design alternative. 🖥️ Local-first desktop app. 🖼️ Your coding agent becomes the design engine: prototypes, landing pages, dashboards, slides, images & video — real files, HTML/PDF/PPTX/MP4 export. 🤖 Claude Code / Codex / Cursor / DeepSeek Harness / OpenCode & 20+ CLIs via BYOK. | `READY · —` | Starred · lock f888d72d5f1a |
+| [pbakaus/impeccable](https://github.com/pbakaus/impeccable) | The design language that makes your AI harness better at design. | `READY · —` | Starred · lock fcd7622cd2d8 |
+| [phuryn/pm-skills](https://github.com/phuryn/pm-skills) | PM Skills Marketplace: 100+ agentic skills, commands, and plugins — from discovery to strategy, execution, launch, and growth. | `READY · —` | Starred · lock 18468a95b427 |
+| [zarazhangrui/tab-out](https://github.com/zarazhangrui/tab-out) | Keep tabs on your tabs. Turn your "New tabs" page into a mission control, so you can close them easily. Built for people who open too many tabs and never close them.  | `READY · —` | Starred · lock 2c9b9c5a92d3 |
+
+## Update contract
+
+- Snapshot ID: `github-universe-2026-08-26` · entries: `37`.
+- Owned and Starred provenance stays visible per row.
+- External products point to a fixed commit SHA; this registry does not follow live branches.
+- Full catalog source and monthly update authority: [Park OS](https://github.com/zinan92/park-operating-system).
+
+## For AI agents
+
+```yaml
+name: product-lab-universe
+universe: product-lab
+source_of_truth: https://github.com/zinan92/park-operating-system
+snapshot_id: github-universe-2026-08-26
+entry_count: 37
+row_semantics: one_repo_one_product_row
+external_versioning: locked_commit_sha
+```
+
+This registry is a product catalog. Validation does not certify product readiness.
 


### PR DESCRIPTION
## What

- Turn the registry README into an rnskill-style homepage.
- Render the full scoped catalog from the canonical snapshot.
- Separate Owned and Starred entries under every stage or product section.
- Show locked external commit SHAs and source states.

## Validation

- Full canonical scoped entry set present
- GitHub Markdown API render: pass
- `git diff --check`: pass
- `gitleaks`: pass
- No source, taxonomy or lock data changed

Closes #3