### PR TITLE
feat: sync reviewed product placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,101 +2,79 @@
 
 # Product Lab
 
-**一个 repo 一行，直接浏览成熟产品。**
+**Product Lab 的 capability-first registry：按子分类浏览 owned 与 starred repo。**
 
-[![Snapshot](https://img.shields.io/badge/snapshot-github--universe--2026--08--26-0969DA)](https://github.com/zinan92/park-operating-system)
-[![Products](https://img.shields.io/badge/products-37-2DA44E)](https://github.com/zinan92/product-lab)
+[![Snapshot](https://img.shields.io/badge/snapshot-33%20repos-0969DA.svg)](snapshot.yaml)
+[![Source](https://img.shields.io/badge/source-Park%20OS-8250DF.svg)](https://github.com/zinan92/park-operating-system)
 
 </div>
 
 ---
 
 ```text
-in  mature product repos from owned + starred universe
-out one-row-per-repo product catalog + direct GitHub links + locked external refs
+in  canonical Park OS snapshot + source provenance + fixed commit locks
+out 33-repo Product Lab map, grouped by function and owned/starred source
 
-fail product metadata sparse → review_status=needs_review
-fail private source inaccessible → keep link + mark PRIVATE
-fail multiple repos represent one product → keep one row per repo; do not aggregate
+fail snapshot checksum mismatch → stop before publishing
+fail private source inaccessible → preserve name/link and mark PRIVATE
+fail unclassified placement → keep needs_review; do not guess
 ```
 
-> Canonical source: [Park OS](https://github.com/zinan92/park-operating-system) · this repo is a generated scoped view.
+Snapshot: `github-universe-2026-08-26-review-01` · canonical source: [Park OS](https://github.com/zinan92/park-operating-system)
 
-## At a glance
+## How to read this page
 
-| Scope | Count |
-|---|---:|
-| Owned products | 11 |
-| Starred products | 26 |
-| Total products | 37 |
+- **Owned** — repo owned by Park.
+- **Starred** — external repo selected as a locked reference.
+- **Lock** — external source is pinned to a commit SHA, not a live branch.
+- **PRIVATE / ARCHIVED** — GitHub visibility or lifecycle flags are preserved.
 
-Product Lab is intentionally flat: there is no stage taxonomy here. A product name, one sentence and one direct link are the unit of navigation.
+## Browse by function
 
-## Owned products
+### Mature Products (33)
 
-| Product | Capability | State | Source |
+| Repo | Capability / description | Source | Lock / flags |
 |---|---|---|---|
-| [zinan92/codex-harness](https://github.com/zinan92/codex-harness) | 本地记录 Codex thread 的 token 使用与项目归属。in Codex session JSONL → out daily thread ledger + read-only HTML UI | `READY · —` | Owned |
-| [zinan92/life-kline](https://github.com/zinan92/life-kline) |  | `READY · PRIVATE` | Owned |
-| [zinan92/paileggemai](https://github.com/zinan92/paileggemai) | 电商商品图生成短视频工作台 | `READY · PRIVATE` | Owned |
-| [zinan92/park-builds](https://github.com/zinan92/park-builds) |  | `READY · —` | Owned |
-| [zinan92/proactive-explorer](https://github.com/zinan92/proactive-explorer) | Strategic product direction finder for open-source repos — 5 MECE categories: Product Depth, Product Reach, Time-to-Value, Trust & Proof, Growth | `READY · —` | Owned |
-| [zinan92/repo-evals](https://github.com/zinan92/repo-evals) | Claim-first repo 评测框架。in target repo + claim map → out bilingual verdict dossier + all-evals dashboard | `READY · —` | Owned |
-| [zinan92/tokenpulse](https://github.com/zinan92/tokenpulse) | 把 Claude/Codex 本地 token 日志变成桌面鞭策 widget、Telegram 推送、CLI 状态和可分享 QR 战绩卡。in 本地日志 + models.dev → out goad widget + share card | `EXPLORING · ARCHIVED` | Owned |
-| [zinan92/tokenrouter](https://github.com/zinan92/tokenrouter) | 个人项目组合工作台：双通道成本账本 + TokenRouter v0 级联内核 | `EXPLORING · ARCHIVED` | Owned |
-| [zinan92/wcstubhub-clone](https://github.com/zinan92/wcstubhub-clone) | 移动优先的票务市场平台 — FIFA 2026 主题，信任架构，智能定价，完整交易流程 | `EXPLORING · ARCHIVED` | Owned |
-| [zinan92/wechat-customer-pipeline](https://github.com/zinan92/wechat-customer-pipeline) | 把授权的本机微信数据库转成私有客户管道与关系行动快照。in WeChat 数据 + 迁移确认 → out HTML + CSV + A/B/C/D + actions + receipts | `READY · PRIVATE` | Owned |
-| [zinan92/wechat-xingqiu](https://github.com/zinan92/wechat-xingqiu) | wechat-xingqiu：原生微信会员内容小程序 | `READY · PRIVATE` | Owned |
-
-## Starred products
-
-| Product | Capability | State / Lock | Source |
-|---|---|---|---|
-| [6tail/tyme4ts](https://github.com/6tail/tyme4ts) | Tyme是一个非常强大的日历工具库，可以看作 Lunar 的升级版，拥有更优的设计和扩展性，支持公历、农历、藏历、回历、星座、干支、生肖、节气、月相、法定假日等。 | `READY · —` | Starred · lock 9e776099e164 |
-| [Brhiza/mingyu](https://github.com/Brhiza/mingyu) | 八字、紫微、星盘、六爻、梅花、奇门、大六壬、小六壬、塔罗、雷诺曼、灵签、择日一站式玄学算命占卜工具包，输出结构化提示词与数据。提供公开 API、MCP Server 与 skill。 | `READY · —` | Starred · lock 1272aa0cd83a |
-| [DestinyLinker/MingLi-Bench](https://github.com/DestinyLinker/MingLi-Bench) | A benchmark for evaluating LLMs on Chinese traditional fortune telling — Bazi (八字) and Ziwei Doushu (紫微斗数). | `READY · —` | Starred · lock b7433280fd86 |
-| [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) | Taste-Skill - gives your AI good taste. stops the AI from generating boring, generic slop  | `READY · —` | Starred · lock ccbc15639c97 |
-| [Renhuai123/ziwei-doushu](https://github.com/Renhuai123/ziwei-doushu) | 紫微斗数开源排盘引擎 — 基于倪海夏《天纪》体系，含完整排盘算法、四化系统、格局知识库、古籍原文数据 | `READY · —` | Starred · lock 88194a404242 |
-| [SylarLong/iztro](https://github.com/SylarLong/iztro) | ⭐This is a lightweight kit for generating astrolabes for Zi Wei Dou Shu (The Purple Star Astrology), an ancient Chinese astrology. It allows you to obtain your horoscope and personality analysis. 支持多语言轻量级获取紫微斗数排盘信息的javascript开源库。 | `READY · —` | Starred · lock 814b77e6371e |
-| [THU-MAIC/OpenMAIC](https://github.com/THU-MAIC/OpenMAIC) | Open Multi-Agent Interactive Classroom — Get an immersive, multi-agent learning experience in just one click | `READY · —` | Starred · lock 1b4a168175e8 |
-| [Usagi-org/ai-goofish-monitor](https://github.com/Usagi-org/ai-goofish-monitor) | 基于 Playwright 和AI实现的闲鱼多任务实时/定时监控与智能分析系统，配备了功能完善的后台管理UI。帮助用户从闲鱼海量商品中，找到心仪产品。 | `EXPLORING · ARCHIVED` | Starred · lock f85d140b6b45 |
-| [afumu/wetrace-skill](https://github.com/afumu/wetrace-skill) | 微信聊天记录skill | `READY · NEEDS_REVIEW` | Starred · lock 6280e9c106a2 |
-| [birobirobiro/awesome-shadcn-ui](https://github.com/birobirobiro/awesome-shadcn-ui) | A curated list of awesome things related to shadcn/ui. | `READY · —` | Starred · lock 7417bbeae2d2 |
-| [chenglou/pretext](https://github.com/chenglou/pretext) | Fast, accurate & comprehensive text measurement & layout | `READY · NEEDS_REVIEW` | Starred · lock ac49b09b7d83 |
-| [chenjin-cmd/wechat-miniprogram-builder](https://github.com/chenjin-cmd/wechat-miniprogram-builder) | wechat-miniprogram-builder | `READY · NEEDS_REVIEW` | Starred · lock e8bba7855d92 |
-| [chuspeeism/dashi-taskboard](https://github.com/chuspeeism/dashi-taskboard) |  | `READY · —` | Starred · lock f0f4cabced1b |
-| [curionox/lifekline](https://github.com/curionox/lifekline) | 人生K线 - 基于AI的八字命理可视化工具 | `READY · —` | Starred · lock b9a27a71260a |
-| [helloianneo/obsidian-ai-second-brain](https://github.com/helloianneo/obsidian-ai-second-brain) | Obsidian + Claude AI 个人知识库完整搭建指南 / 基于 Karpathy LLM Wiki 方法论 / 4 阶段 12 步 / 不用写代码 | `READY · —` | Starred · lock fb3468a1d5fa |
-| [idootop/open-xiaoai](https://github.com/idootop/open-xiaoai) | 🔊 让小爱音箱「听见你的声音」，解锁无限可能。  | `EXPLORING · ARCHIVED, NEEDS_REVIEW` | Starred · lock bc3396c64e2a |
-| [iptv-org/iptv](https://github.com/iptv-org/iptv) | Collection of publicly available IPTV channels from all over the world | `READY · —` | Starred · lock b0390e5c6a48 |
-| [learnwithu/mingli-master](https://github.com/learnwithu/mingli-master) | 紫微斗数命盘解读 skill · 基于 iztro-py 精确排盘，生成可视化命盘 HTML | `READY · —` | Starred · lock 000da99552cd |
-| [miounet11/life-kline](https://github.com/miounet11/life-kline) | 🌟 人生K线 - 基于 AI 大模型 + 传统八字命理的人生运势可视化工具。将命运绘制成 K 线图，像看股票一样看人生！支持自托管部署。 | `READY · —` | Starred · lock 7abf184df370 |
-| [n8n-io/n8n](https://github.com/n8n-io/n8n) | Fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations. | `READY · —` | Starred · lock 48c42fa4b8ca |
-| [nextlevelbuilder/ui-ux-pro-max-skill](https://github.com/nextlevelbuilder/ui-ux-pro-max-skill) | An AI skill that provides design intelligence for building professional UI/UX across multiple platforms. | `READY · —` | Starred · lock e353a508767c |
-| [nexu-io/html-anything](https://github.com/nexu-io/html-anything) | ✨ The agentic HTML editor — your local AI agent writes the HTML, you ship it. 🚀 75 Skills × 9 Surfaces (magazine · deck · poster · XHS / tweet · prototype · data report · Hyperframes) 🛡️ Sandboxed preview · 📤 1-click to WeChat / X / Zhihu / HTML / PNG 🔑 Zero API key — Claude Code / Cursor / Codex / Gemini / Copilot / OpenCode / Qwen / Aider. | `READY · —` | Starred · lock c31204544230 |
-| [nexu-io/open-design](https://github.com/nexu-io/open-design) | 🎨 Best DeepSeek Harness Design Plugin. The open-source Claude Design alternative. 🖥️ Local-first desktop app. 🖼️ Your coding agent becomes the design engine: prototypes, landing pages, dashboards, slides, images & video — real files, HTML/PDF/PPTX/MP4 export. 🤖 Claude Code / Codex / Cursor / DeepSeek Harness / OpenCode & 20+ CLIs via BYOK. | `READY · —` | Starred · lock f888d72d5f1a |
-| [pbakaus/impeccable](https://github.com/pbakaus/impeccable) | The design language that makes your AI harness better at design. | `READY · —` | Starred · lock fcd7622cd2d8 |
-| [phuryn/pm-skills](https://github.com/phuryn/pm-skills) | PM Skills Marketplace: 100+ agentic skills, commands, and plugins — from discovery to strategy, execution, launch, and growth. | `READY · —` | Starred · lock 18468a95b427 |
-| [zarazhangrui/tab-out](https://github.com/zarazhangrui/tab-out) | Keep tabs on your tabs. Turn your "New tabs" page into a mission control, so you can close them easily. Built for people who open too many tabs and never close them.  | `READY · —` | Starred · lock 2c9b9c5a92d3 |
+| [6tail/tyme4ts](https://github.com/6tail/tyme4ts) | Tyme是一个非常强大的日历工具库，可以看作 Lunar 的升级版，拥有更优的设计和扩展性，支持公历、农历、藏历、回历、星座、干支、生肖、节气、月相、法定假日等。 | Starred | `9e776099e164` |
+| [afumu/wetrace-skill](https://github.com/afumu/wetrace-skill) | 微信聊天记录skill | Starred | `6280e9c106a2` |
+| [birobirobiro/awesome-shadcn-ui](https://github.com/birobirobiro/awesome-shadcn-ui) | A curated list of awesome things related to shadcn/ui. | Starred | `7417bbeae2d2` |
+| [Brhiza/mingyu](https://github.com/Brhiza/mingyu) | 八字、紫微、星盘、六爻、梅花、奇门、大六壬、小六壬、塔罗、雷诺曼、灵签、择日一站式玄学算命占卜工具包，输出结构化提示词与数据。提供公开 API、MCP Server 与 skill。 | Starred | `1272aa0cd83a` |
+| [chenglou/pretext](https://github.com/chenglou/pretext) | Fast, accurate & comprehensive text measurement & layout | Starred | `ac49b09b7d83` |
+| [chenjin-cmd/wechat-miniprogram-builder](https://github.com/chenjin-cmd/wechat-miniprogram-builder) | wechat-miniprogram-builder | Starred | `e8bba7855d92` |
+| [chuspeeism/dashi-taskboard](https://github.com/chuspeeism/dashi-taskboard) | No description | Starred | `f0f4cabced1b` |
+| [curionox/lifekline](https://github.com/curionox/lifekline) | 人生K线 - 基于AI的八字命理可视化工具 | Starred | `b9a27a71260a` |
+| [DestinyLinker/MingLi-Bench](https://github.com/DestinyLinker/MingLi-Bench) | A benchmark for evaluating LLMs on Chinese traditional fortune telling — Bazi (八字) and Ziwei Doushu (紫微斗数). | Starred | `b7433280fd86` |
+| [helloianneo/obsidian-ai-second-brain](https://github.com/helloianneo/obsidian-ai-second-brain) | Obsidian + Claude AI 个人知识库完整搭建指南 \| 基于 Karpathy LLM Wiki 方法论 \| 4 阶段 12 步 \| 不用写代码 | Starred | `fb3468a1d5fa` |
+| [idootop/open-xiaoai](https://github.com/idootop/open-xiaoai) | 🔊 让小爱音箱「听见你的声音」，解锁无限可能。 | Starred | `bc3396c64e2a` · ARCHIVED |
+| [iptv-org/iptv](https://github.com/iptv-org/iptv) | Collection of publicly available IPTV channels from all over the world | Starred | `b0390e5c6a48` |
+| [learnwithu/mingli-master](https://github.com/learnwithu/mingli-master) | 紫微斗数命盘解读 skill · 基于 iztro-py 精确排盘，生成可视化命盘 HTML | Starred | `000da99552cd` |
+| [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) | Taste-Skill - gives your AI good taste. stops the AI from generating boring, generic slop | Starred | `ccbc15639c97` |
+| [Ming-H/yinyuan-skills](https://github.com/Ming-H/yinyuan-skills) | yinyuan-skills | Starred | `b091c8861a14` |
+| [miounet11/life-kline](https://github.com/miounet11/life-kline) | 🌟 人生K线 - 基于 AI 大模型 + 传统八字命理的人生运势可视化工具。将命运绘制成 K 线图，像看股票一样看人生！支持自托管部署。 | Starred | `7abf184df370` |
+| [Renhuai123/ziwei-doushu](https://github.com/Renhuai123/ziwei-doushu) | 紫微斗数开源排盘引擎 — 基于倪海夏《天纪》体系，含完整排盘算法、四化系统、格局知识库、古籍原文数据 | Starred | `88194a404242` |
+| [Shubham0812/SwiftUI-Animations](https://github.com/Shubham0812/SwiftUI-Animations) | A repository containing a variety of animations and Animated components created in SwiftUI that you can use in your own projects. | Starred | `030bd1c710f9` |
+| [SylarLong/iztro](https://github.com/SylarLong/iztro) | ⭐This is a lightweight kit for generating astrolabes for Zi Wei Dou Shu (The Purple Star Astrology), an ancient Chinese astrology. It allows you to obtain your horoscope and personality analysis. 支持多语言轻量级获取紫微斗数排盘信息的javascript开源库。 | Starred | `814b77e6371e` |
+| [THU-MAIC/OpenMAIC](https://github.com/THU-MAIC/OpenMAIC) | Open Multi-Agent Interactive Classroom — Get an immersive, multi-agent learning experience in just one click | Starred | `1b4a168175e8` |
+| [Usagi-org/ai-goofish-monitor](https://github.com/Usagi-org/ai-goofish-monitor) | 基于 Playwright 和AI实现的闲鱼多任务实时/定时监控与智能分析系统，配备了功能完善的后台管理UI。帮助用户从闲鱼海量商品中，找到心仪产品。 | Starred | `f85d140b6b45` · ARCHIVED |
+| [zarazhangrui/tab-out](https://github.com/zarazhangrui/tab-out) | Keep tabs on your tabs. Turn your "New tabs" page into a mission control, so you can close them easily. Built for people who open too many tabs and never close them. | Starred | `2c9b9c5a92d3` |
+| [zinan92/codex-harness](https://github.com/zinan92/codex-harness) | 本地记录 Codex thread 的 token 使用与项目归属。in Codex session JSONL → out daily thread ledger + read-only HTML UI | Owned + Starred | owned source |
+| [zinan92/life-kline](https://github.com/zinan92/life-kline) | No description | Owned | owned source · PRIVATE |
+| [zinan92/paileggemai](https://github.com/zinan92/paileggemai) | 电商商品图生成短视频工作台 | Owned | owned source · PRIVATE |
+| [zinan92/park-builds](https://github.com/zinan92/park-builds) | No description | Owned | owned source |
+| [zinan92/proactive-explorer](https://github.com/zinan92/proactive-explorer) | Strategic product direction finder for open-source repos — 5 MECE categories: Product Depth, Product Reach, Time-to-Value, Trust & Proof, Growth | Owned | owned source |
+| [zinan92/repo-evals](https://github.com/zinan92/repo-evals) | Claim-first repo 评测框架。in target repo + claim map → out bilingual verdict dossier + all-evals dashboard | Owned + Starred | owned source |
+| [zinan92/tokenpulse](https://github.com/zinan92/tokenpulse) | 把 Claude/Codex 本地 token 日志变成桌面鞭策 widget、Telegram 推送、CLI 状态和可分享 QR 战绩卡。in 本地日志 + models.dev → out goad widget + share card | Owned | owned source · ARCHIVED |
+| [zinan92/tokenrouter](https://github.com/zinan92/tokenrouter) | 个人项目组合工作台：双通道成本账本 + TokenRouter v0 级联内核 | Owned | owned source · ARCHIVED |
+| [zinan92/wcstubhub-clone](https://github.com/zinan92/wcstubhub-clone) | 移动优先的票务市场平台 — FIFA 2026 主题，信任架构，智能定价，完整交易流程 | Owned | owned source · ARCHIVED |
+| [zinan92/wechat-customer-pipeline](https://github.com/zinan92/wechat-customer-pipeline) | 把授权的本机微信数据库转成私有客户管道与关系行动快照。in WeChat 数据 + 迁移确认 → out HTML + CSV + A/B/C/D + actions + receipts | Owned | owned source · PRIVATE |
+| [zinan92/wechat-xingqiu](https://github.com/zinan92/wechat-xingqiu) | wechat-xingqiu：原生微信会员内容小程序 | Owned | owned source · PRIVATE |
 
 ## Update contract
 
-- Snapshot ID: `github-universe-2026-08-26` · entries: `37`.
-- Owned and Starred provenance stays visible per row.
-- External products point to a fixed commit SHA; this registry does not follow live branches.
-- Full catalog source and monthly update authority: [Park OS](https://github.com/zinan92/park-operating-system).
+This README and the generated data are scoped views. Taxonomy, source state and lock authority remain in Park OS.
 
-## For AI agents
-
-```yaml
-name: product-lab-universe
-universe: product-lab
-source_of_truth: https://github.com/zinan92/park-operating-system
-snapshot_id: github-universe-2026-08-26
-entry_count: 37
-row_semantics: one_repo_one_product_row
-external_versioning: locked_commit_sha
+```bash
+bash scripts/verify-scoped.sh
 ```
 
-This registry is a product catalog. Validation does not certify product readiness.
-
+The registry is a catalog, not a production-readiness or execution-authorization claim.

--- a/entries/archived.yaml
+++ b/entries/archived.yaml
@@ -1,4 +1,4 @@
-snapshot_id: github-universe-2026-08-26
+snapshot_id: github-universe-2026-08-26-review-01
 entries:
 - universe: product-lab
   repo: Usagi-org/ai-goofish-monitor
@@ -25,12 +25,12 @@ entries:
     archived: true
     description: 基于 Playwright 和AI实现的闲鱼多任务实时/定时监控与智能分析系统，配备了功能完善的后台管理UI。帮助用户从闲鱼海量商品中，找到心仪产品。
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-05-18T10:52:34Z'
   content_lock:
     locked_ref: f85d140b6b45029d9a0925feb96dad733b41396d
     locked_url: https://github.com/Usagi-org/ai-goofish-monitor/commit/f85d140b6b45029d9a0925feb96dad733b41396d
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -57,12 +57,12 @@ entries:
     archived: true
     description: '🔊 让小爱音箱「听见你的声音」，解锁无限可能。 '
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-04-04T07:58:12Z'
   content_lock:
     locked_ref: bc3396c64e2a435f354eb5cb12a203981f1fe422
     locked_url: https://github.com/idootop/open-xiaoai/commit/bc3396c64e2a435f354eb5cb12a203981f1fe422
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -91,7 +91,7 @@ entries:
     description: 把 Claude/Codex 本地 token 日志变成桌面鞭策 widget、Telegram 推送、CLI 状态和可分享 QR 战绩卡。in 本地日志 + models.dev → out goad widget
       + share card
     license_spdx: NOASSERTION
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-07-28T16:01:13Z'
 - universe: product-lab
   repo: zinan92/tokenrouter
@@ -117,7 +117,7 @@ entries:
     archived: true
     description: 个人项目组合工作台：双通道成本账本 + TokenRouter v0 级联内核
     license_spdx: NOASSERTION
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-08-02T08:59:59Z'
 - universe: product-lab
   repo: zinan92/wcstubhub-clone
@@ -143,5 +143,5 @@ entries:
     archived: true
     description: 移动优先的票务市场平台 — FIFA 2026 主题，信任架构，智能定价，完整交易流程
     license_spdx: NOASSERTION
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-03-27T14:18:50Z'

--- a/entries/owned.yaml
+++ b/entries/owned.yaml
@@ -1,4 +1,4 @@
-snapshot_id: github-universe-2026-08-26
+snapshot_id: github-universe-2026-08-26-review-01
 entries:
 - universe: product-lab
   repo: zinan92/codex-harness
@@ -23,7 +23,7 @@ entries:
     archived: false
     description: 本地记录 Codex thread 的 token 使用与项目归属。in Codex session JSONL → out daily thread ledger + read-only HTML UI
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-08-04T06:20:07Z'
 - universe: product-lab
   repo: zinan92/life-kline
@@ -49,7 +49,7 @@ entries:
     archived: false
     description: ''
     license_spdx: NOASSERTION
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-07-22T08:47:55Z'
 - universe: product-lab
   repo: zinan92/paileggemai
@@ -75,7 +75,7 @@ entries:
     archived: false
     description: 电商商品图生成短视频工作台
     license_spdx: NOASSERTION
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-07-22T12:23:24Z'
 - universe: product-lab
   repo: zinan92/park-builds
@@ -99,7 +99,7 @@ entries:
     archived: false
     description: ''
     license_spdx: NOASSERTION
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-06-04T16:18:27Z'
 - universe: product-lab
   repo: zinan92/proactive-explorer
@@ -126,7 +126,7 @@ entries:
     description: 'Strategic product direction finder for open-source repos — 5 MECE categories: Product Depth, Product Reach,
       Time-to-Value, Trust & Proof, Growth'
     license_spdx: NOASSERTION
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-03-19T06:43:22Z'
 - universe: product-lab
   repo: zinan92/repo-evals
@@ -151,7 +151,7 @@ entries:
     archived: false
     description: Claim-first repo 评测框架。in target repo + claim map → out bilingual verdict dossier + all-evals dashboard
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-07-09T15:41:46Z'
 - universe: product-lab
   repo: zinan92/wechat-customer-pipeline
@@ -178,7 +178,7 @@ entries:
     archived: false
     description: 把授权的本机微信数据库转成私有客户管道与关系行动快照。in WeChat 数据 + 迁移确认 → out HTML + CSV + A/B/C/D + actions + receipts
     license_spdx: NOASSERTION
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-08-07T10:11:39Z'
 - universe: product-lab
   repo: zinan92/wechat-xingqiu
@@ -204,5 +204,5 @@ entries:
     archived: false
     description: wechat-xingqiu：原生微信会员内容小程序
     license_spdx: NOASSERTION
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-08-24T18:24:36Z'

--- a/entries/starred.yaml
+++ b/entries/starred.yaml
@@ -1,4 +1,4 @@
-snapshot_id: github-universe-2026-08-26
+snapshot_id: github-universe-2026-08-26-review-01
 entries:
 - universe: product-lab
   repo: 6tail/tyme4ts
@@ -23,12 +23,12 @@ entries:
     archived: false
     description: Tyme是一个非常强大的日历工具库，可以看作 Lunar 的升级版，拥有更优的设计和扩展性，支持公历、农历、藏历、回历、星座、干支、生肖、节气、月相、法定假日等。
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-08-17T09:47:13Z'
   content_lock:
     locked_ref: 9e776099e164c43fd932684875057fe345773241
     locked_url: https://github.com/6tail/tyme4ts/commit/9e776099e164c43fd932684875057fe345773241
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -56,12 +56,12 @@ entries:
     archived: false
     description: 八字、紫微、星盘、六爻、梅花、奇门、大六壬、小六壬、塔罗、雷诺曼、灵签、择日一站式玄学算命占卜工具包，输出结构化提示词与数据。提供公开 API、MCP Server 与 skill。
     license_spdx: NOASSERTION
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-08-25T12:30:06Z'
   content_lock:
     locked_ref: 1272aa0cd83a802e78b61568571f709517a1e369
     locked_url: https://github.com/Brhiza/mingyu/commit/1272aa0cd83a802e78b61568571f709517a1e369
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -87,12 +87,12 @@ entries:
     archived: false
     description: A benchmark for evaluating LLMs on Chinese traditional fortune telling — Bazi (八字) and Ziwei Doushu (紫微斗数).
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-05-09T17:49:34Z'
   content_lock:
     locked_ref: b7433280fd86d7a7c27debbc47d0303c218f0bfd
     locked_url: https://github.com/DestinyLinker/MingLi-Bench/commit/b7433280fd86d7a7c27debbc47d0303c218f0bfd
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -119,12 +119,43 @@ entries:
     archived: false
     description: 'Taste-Skill - gives your AI good taste. stops the AI from generating boring, generic slop '
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-08-24T15:23:56Z'
   content_lock:
     locked_ref: ccbc15639c97057cbfcf32ecebc38ef716e4bb37
     locked_url: https://github.com/Leonxlnx/taste-skill/commit/ccbc15639c97057cbfcf32ecebc38ef716e4bb37
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
+    update_policy: monthly_pr
+    vendored: false
+- universe: product-lab
+  repo: Ming-H/yinyuan-skills
+  owned: false
+  starred: true
+  source_kind: starred
+  registry_repo: false
+  registry_role: null
+  primary_category: product
+  tags:
+  - skill
+  source_url: https://github.com/Ming-H/yinyuan-skills
+  visibility: public
+  archived: false
+  description: yinyuan-skills
+  status: READY
+  review_status: confirmed
+  review_reason: null
+  github_snapshot:
+    default_branch: main
+    visibility: public
+    archived: false
+    description: yinyuan-skills
+    license_spdx: NOASSERTION
+    checked_at: 2026-08-26-review-01
+    pushed_at: '2026-04-05T08:09:38Z'
+  content_lock:
+    locked_ref: b091c8861a148b8260dedfbd06fc10daf7f886fc
+    locked_url: https://github.com/Ming-H/yinyuan-skills/commit/b091c8861a148b8260dedfbd06fc10daf7f886fc
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -150,12 +181,44 @@ entries:
     archived: false
     description: 紫微斗数开源排盘引擎 — 基于倪海夏《天纪》体系，含完整排盘算法、四化系统、格局知识库、古籍原文数据
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-06-24T07:24:36Z'
   content_lock:
     locked_ref: 88194a404242bfe5c6d5cc512e4117e3e245cdd5
     locked_url: https://github.com/Renhuai123/ziwei-doushu/commit/88194a404242bfe5c6d5cc512e4117e3e245cdd5
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
+    update_policy: monthly_pr
+    vendored: false
+- universe: product-lab
+  repo: Shubham0812/SwiftUI-Animations
+  owned: false
+  starred: true
+  source_kind: starred
+  registry_repo: false
+  registry_role: null
+  primary_category: product
+  tags: []
+  source_url: https://github.com/Shubham0812/SwiftUI-Animations
+  visibility: public
+  archived: false
+  description: A repository containing a variety of animations and Animated components created in SwiftUI that you can use
+    in your own projects.
+  status: READY
+  review_status: needs_review
+  review_reason: 'new-star-review: reusable SwiftUI animation components; provisional Product Lab product/library placement.'
+  github_snapshot:
+    default_branch: master
+    visibility: public
+    archived: false
+    description: A repository containing a variety of animations and Animated components created in SwiftUI that you can use
+      in your own projects.
+    license_spdx: Apache-2.0
+    checked_at: 2026-08-26-review-01
+    pushed_at: '2026-08-11T15:20:15Z'
+  content_lock:
+    locked_ref: 030bd1c710f9cdcc30b30e3912b361990e473be1
+    locked_url: https://github.com/Shubham0812/SwiftUI-Animations/commit/030bd1c710f9cdcc30b30e3912b361990e473be1
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -184,12 +247,12 @@ entries:
     description: ⭐This is a lightweight kit for generating astrolabes for Zi Wei Dou Shu (The Purple Star Astrology), an ancient
       Chinese astrology. It allows you to obtain your horoscope and personality analysis. 支持多语言轻量级获取紫微斗数排盘信息的javascript开源库。
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-08-19T15:46:01Z'
   content_lock:
     locked_ref: 814b77e6371e1050cac31bbf674db3c3138fcfde
     locked_url: https://github.com/SylarLong/iztro/commit/814b77e6371e1050cac31bbf674db3c3138fcfde
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -216,12 +279,12 @@ entries:
     archived: false
     description: Open Multi-Agent Interactive Classroom — Get an immersive, multi-agent learning experience in just one click
     license_spdx: MIT
-    checked_at: '2026-08-26'
-    pushed_at: '2026-08-26T03:03:18Z'
+    checked_at: 2026-08-26-review-01
+    pushed_at: '2026-08-26T08:34:51Z'
   content_lock:
     locked_ref: 1b4a168175e88057c77869196f7da8ef657fcb2f
     locked_url: https://github.com/THU-MAIC/OpenMAIC/commit/1b4a168175e88057c77869196f7da8ef657fcb2f
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -248,12 +311,12 @@ entries:
     archived: false
     description: 微信聊天记录skill
     license_spdx: NOASSERTION
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-02-14T08:51:02Z'
   content_lock:
     locked_ref: 6280e9c106a2549340bf750ccae71f4053ed4710
     locked_url: https://github.com/afumu/wetrace-skill/commit/6280e9c106a2549340bf750ccae71f4053ed4710
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -280,12 +343,12 @@ entries:
     archived: false
     description: A curated list of awesome things related to shadcn/ui.
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-08-24T03:57:40Z'
   content_lock:
     locked_ref: 7417bbeae2d214b0991fa49b4a42d2844fa0c54b
     locked_url: https://github.com/birobirobiro/awesome-shadcn-ui/commit/7417bbeae2d214b0991fa49b4a42d2844fa0c54b
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -311,12 +374,12 @@ entries:
     archived: false
     description: Fast, accurate & comprehensive text measurement & layout
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-06-23T05:01:09Z'
   content_lock:
     locked_ref: ac49b09b7d83ede19581fa94a8b892b07d309baf
     locked_url: https://github.com/chenglou/pretext/commit/ac49b09b7d83ede19581fa94a8b892b07d309baf
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -341,12 +404,12 @@ entries:
     archived: false
     description: wechat-miniprogram-builder
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-08-01T15:58:29Z'
   content_lock:
     locked_ref: e8bba7855d9209451b2d2b5a9fa17c15b8d42401
     locked_url: https://github.com/chenjin-cmd/wechat-miniprogram-builder/commit/e8bba7855d9209451b2d2b5a9fa17c15b8d42401
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -372,12 +435,12 @@ entries:
     archived: false
     description: ''
     license_spdx: Apache-2.0
-    checked_at: '2026-08-26'
-    pushed_at: '2026-08-25T20:21:18Z'
+    checked_at: 2026-08-26-review-01
+    pushed_at: '2026-08-26T08:47:33Z'
   content_lock:
     locked_ref: f0f4cabced1b15e47c852438a9a599d245a38063
     locked_url: https://github.com/chuspeeism/dashi-taskboard/commit/f0f4cabced1b15e47c852438a9a599d245a38063
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -402,12 +465,12 @@ entries:
     archived: false
     description: 人生K线 - 基于AI的八字命理可视化工具
     license_spdx: NOASSERTION
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2025-12-14T13:09:01Z'
   content_lock:
     locked_ref: b9a27a71260a09f26a1e3757fbee2ba71f52773b
     locked_url: https://github.com/curionox/lifekline/commit/b9a27a71260a09f26a1e3757fbee2ba71f52773b
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -433,12 +496,12 @@ entries:
     archived: false
     description: Obsidian + Claude AI 个人知识库完整搭建指南 | 基于 Karpathy LLM Wiki 方法论 | 4 阶段 12 步 | 不用写代码
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-04-13T09:34:10Z'
   content_lock:
     locked_ref: fb3468a1d5facf6f42bcce4db4d161dabd1fd615
     locked_url: https://github.com/helloianneo/obsidian-ai-second-brain/commit/fb3468a1d5facf6f42bcce4db4d161dabd1fd615
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -465,12 +528,12 @@ entries:
     archived: false
     description: Collection of publicly available IPTV channels from all over the world
     license_spdx: Unlicense
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-08-26T00:09:32Z'
   content_lock:
     locked_ref: b0390e5c6a48065a7def742421353a6109fd3bbd
     locked_url: https://github.com/iptv-org/iptv/commit/b0390e5c6a48065a7def742421353a6109fd3bbd
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -497,12 +560,12 @@ entries:
     archived: false
     description: 紫微斗数命盘解读 skill · 基于 iztro-py 精确排盘，生成可视化命盘 HTML
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-08-15T12:51:17Z'
   content_lock:
     locked_ref: 000da99552cdfdbdfde49f6e76b014515b8ea51c
     locked_url: https://github.com/learnwithu/mingli-master/commit/000da99552cdfdbdfde49f6e76b014515b8ea51c
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -528,225 +591,12 @@ entries:
     archived: false
     description: 🌟 人生K线 - 基于 AI 大模型 + 传统八字命理的人生运势可视化工具。将命运绘制成 K 线图，像看股票一样看人生！支持自托管部署。
     license_spdx: Apache-2.0
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2025-12-22T09:41:30Z'
   content_lock:
     locked_ref: 7abf184df370452ee8279d72c8b45bc09e19913b
     locked_url: https://github.com/miounet11/life-kline/commit/7abf184df370452ee8279d72c8b45bc09e19913b
-    locked_at: '2026-08-26'
-    update_policy: monthly_pr
-    vendored: false
-- universe: product-lab
-  repo: n8n-io/n8n
-  owned: false
-  starred: true
-  source_kind: starred
-  registry_repo: false
-  registry_role: null
-  primary_category: product
-  tags:
-  - product
-  - typescript
-  - workflow
-  source_url: https://github.com/n8n-io/n8n
-  visibility: public
-  archived: false
-  description: Fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code,
-    self-host or cloud, 400+ integrations.
-  status: READY
-  review_status: confirmed
-  review_reason: null
-  github_snapshot:
-    default_branch: master
-    visibility: public
-    archived: false
-    description: Fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code,
-      self-host or cloud, 400+ integrations.
-    license_spdx: NOASSERTION
-    checked_at: '2026-08-26'
-    pushed_at: '2026-08-25T23:55:55Z'
-  content_lock:
-    locked_ref: 48c42fa4b8caba99f415b06ca2a3d2090fa46636
-    locked_url: https://github.com/n8n-io/n8n/commit/48c42fa4b8caba99f415b06ca2a3d2090fa46636
-    locked_at: '2026-08-26'
-    update_policy: monthly_pr
-    vendored: false
-- universe: product-lab
-  repo: nextlevelbuilder/ui-ux-pro-max-skill
-  owned: false
-  starred: true
-  source_kind: starred
-  registry_repo: false
-  registry_role: null
-  primary_category: product
-  tags:
-  - image
-  - product
-  - python
-  - skill
-  source_url: https://github.com/nextlevelbuilder/ui-ux-pro-max-skill
-  visibility: public
-  archived: false
-  description: An AI skill that provides design intelligence for building professional UI/UX across multiple platforms.
-  status: READY
-  review_status: confirmed
-  review_reason: null
-  github_snapshot:
-    default_branch: main
-    visibility: public
-    archived: false
-    description: An AI skill that provides design intelligence for building professional UI/UX across multiple platforms.
-    license_spdx: MIT
-    checked_at: '2026-08-26'
-    pushed_at: '2026-08-25T15:27:04Z'
-  content_lock:
-    locked_ref: e353a508767c6d39f0e7698b084dbfc8699fffd3
-    locked_url: https://github.com/nextlevelbuilder/ui-ux-pro-max-skill/commit/e353a508767c6d39f0e7698b084dbfc8699fffd3
-    locked_at: '2026-08-26'
-    update_policy: monthly_pr
-    vendored: false
-- universe: product-lab
-  repo: nexu-io/html-anything
-  owned: false
-  starred: true
-  source_kind: starred
-  registry_repo: false
-  registry_role: null
-  primary_category: product
-  tags:
-  - api
-  - skill
-  source_url: https://github.com/nexu-io/html-anything
-  visibility: public
-  archived: false
-  description: ✨ The agentic HTML editor — your local AI agent writes the HTML, you ship it. 🚀 75 Skills × 9 Surfaces (magazine
-    · deck · poster · XHS / tweet · prototype · data report · Hyperframes) 🛡️ Sandboxed preview · 📤 1-click to WeChat / X
-    / Zhihu / HTML / PNG 🔑 Zero API key — Claude Code / Cursor / Codex / Gemini / Copilot / OpenCode / Qwen / Aider.
-  status: READY
-  review_status: confirmed
-  review_reason: null
-  github_snapshot:
-    default_branch: main
-    visibility: public
-    archived: false
-    description: ✨ The agentic HTML editor — your local AI agent writes the HTML, you ship it. 🚀 75 Skills × 9 Surfaces (magazine
-      · deck · poster · XHS / tweet · prototype · data report · Hyperframes) 🛡️ Sandboxed preview · 📤 1-click to WeChat /
-      X / Zhihu / HTML / PNG 🔑 Zero API key — Claude Code / Cursor / Codex / Gemini / Copilot / OpenCode / Qwen / Aider.
-    license_spdx: Apache-2.0
-    checked_at: '2026-08-26'
-    pushed_at: '2026-08-23T08:53:57Z'
-  content_lock:
-    locked_ref: c31204544230578ac814026fecc153c6e36587ae
-    locked_url: https://github.com/nexu-io/html-anything/commit/c31204544230578ac814026fecc153c6e36587ae
-    locked_at: '2026-08-26'
-    update_policy: monthly_pr
-    vendored: false
-- universe: product-lab
-  repo: nexu-io/open-design
-  owned: false
-  starred: true
-  source_kind: starred
-  registry_repo: false
-  registry_role: null
-  primary_category: product
-  tags:
-  - dashboard
-  - image
-  - product
-  - skill
-  - typescript
-  - video
-  source_url: https://github.com/nexu-io/open-design
-  visibility: public
-  archived: false
-  description: '🎨 Best DeepSeek Harness Design Plugin. The open-source Claude Design alternative. 🖥️ Local-first desktop app.
-    🖼️ Your coding agent becomes the design engine: prototypes, landing pages, dashboards, slides, images & video — real files,
-    HTML/PDF/PPTX/MP4 export. 🤖 Claude Code / Codex / Cursor / DeepSeek Harness / OpenCode & 20+ CLIs via BYOK.'
-  status: READY
-  review_status: confirmed
-  review_reason: null
-  github_snapshot:
-    default_branch: main
-    visibility: public
-    archived: false
-    description: '🎨 Best DeepSeek Harness Design Plugin. The open-source Claude Design alternative. 🖥️ Local-first desktop
-      app. 🖼️ Your coding agent becomes the design engine: prototypes, landing pages, dashboards, slides, images & video —
-      real files, HTML/PDF/PPTX/MP4 export. 🤖 Claude Code / Codex / Cursor / DeepSeek Harness / OpenCode & 20+ CLIs via BYOK.'
-    license_spdx: Apache-2.0
-    checked_at: '2026-08-26'
-    pushed_at: '2026-08-26T02:48:47Z'
-  content_lock:
-    locked_ref: f888d72d5f1a6e486bf0448ef171b4e452b1e58f
-    locked_url: https://github.com/nexu-io/open-design/commit/f888d72d5f1a6e486bf0448ef171b4e452b1e58f
-    locked_at: '2026-08-26'
-    update_policy: monthly_pr
-    vendored: false
-- universe: product-lab
-  repo: pbakaus/impeccable
-  owned: false
-  starred: true
-  source_kind: starred
-  registry_repo: false
-  registry_role: null
-  primary_category: product
-  tags:
-  - image
-  - javascript
-  source_url: https://github.com/pbakaus/impeccable
-  visibility: public
-  archived: false
-  description: The design language that makes your AI harness better at design.
-  status: READY
-  review_status: confirmed
-  review_reason: null
-  github_snapshot:
-    default_branch: main
-    visibility: public
-    archived: false
-    description: The design language that makes your AI harness better at design.
-    license_spdx: Apache-2.0
-    checked_at: '2026-08-26'
-    pushed_at: '2026-08-25T19:07:13Z'
-  content_lock:
-    locked_ref: fcd7622cd2d8e2b09344ba8ede9fcac82cec4e70
-    locked_url: https://github.com/pbakaus/impeccable/commit/fcd7622cd2d8e2b09344ba8ede9fcac82cec4e70
-    locked_at: '2026-08-26'
-    update_policy: monthly_pr
-    vendored: false
-- universe: product-lab
-  repo: phuryn/pm-skills
-  owned: false
-  starred: true
-  source_kind: starred
-  registry_repo: false
-  registry_role: null
-  primary_category: product
-  tags:
-  - image
-  - research
-  - skill
-  - video
-  source_url: https://github.com/phuryn/pm-skills
-  visibility: public
-  archived: false
-  description: 'PM Skills Marketplace: 100+ agentic skills, commands, and plugins — from discovery to strategy, execution,
-    launch, and growth.'
-  status: READY
-  review_status: confirmed
-  review_reason: null
-  github_snapshot:
-    default_branch: main
-    visibility: public
-    archived: false
-    description: 'PM Skills Marketplace: 100+ agentic skills, commands, and plugins — from discovery to strategy, execution,
-      launch, and growth.'
-    license_spdx: MIT
-    checked_at: '2026-08-26'
-    pushed_at: '2026-07-03T11:34:49Z'
-  content_lock:
-    locked_ref: 18468a95b427e70e258b51389796367c6f684e7d
-    locked_url: https://github.com/phuryn/pm-skills/commit/18468a95b427e70e258b51389796367c6f684e7d
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -774,11 +624,11 @@ entries:
     description: 'Keep tabs on your tabs. Turn your "New tabs" page into a mission control, so you can close them easily.
       Built for people who open too many tabs and never close them. '
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-04-14T22:27:23Z'
   content_lock:
     locked_ref: 2c9b9c5a92d37e2bc1d1f121986f880467e0ef92
     locked_url: https://github.com/zarazhangrui/tab-out/commit/2c9b9c5a92d37e2bc1d1f121986f880467e0ef92
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false

--- a/locks/sources.lock.yaml
+++ b/locks/sources.lock.yaml
@@ -1,12 +1,12 @@
-snapshot_id: github-universe-2026-08-26
-generated_from_checksum: 76ea409b99523b3b5a289cfa07290a8e73d9c13cb9b311ff652395858d379ad1
+snapshot_id: github-universe-2026-08-26-review-01
+generated_from_checksum: 0aade4a0fd73c7283739914f8e1ae0629ba7417296106fb1dcbb346964f24a55
 locks:
 - repo: 6tail/tyme4ts
   source_url: https://github.com/6tail/tyme4ts
   content_lock:
     locked_ref: 9e776099e164c43fd932684875057fe345773241
     locked_url: https://github.com/6tail/tyme4ts/commit/9e776099e164c43fd932684875057fe345773241
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: Brhiza/mingyu
@@ -14,7 +14,7 @@ locks:
   content_lock:
     locked_ref: 1272aa0cd83a802e78b61568571f709517a1e369
     locked_url: https://github.com/Brhiza/mingyu/commit/1272aa0cd83a802e78b61568571f709517a1e369
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: DestinyLinker/MingLi-Bench
@@ -22,7 +22,7 @@ locks:
   content_lock:
     locked_ref: b7433280fd86d7a7c27debbc47d0303c218f0bfd
     locked_url: https://github.com/DestinyLinker/MingLi-Bench/commit/b7433280fd86d7a7c27debbc47d0303c218f0bfd
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: Leonxlnx/taste-skill
@@ -30,7 +30,15 @@ locks:
   content_lock:
     locked_ref: ccbc15639c97057cbfcf32ecebc38ef716e4bb37
     locked_url: https://github.com/Leonxlnx/taste-skill/commit/ccbc15639c97057cbfcf32ecebc38ef716e4bb37
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
+    update_policy: monthly_pr
+    vendored: false
+- repo: Ming-H/yinyuan-skills
+  source_url: https://github.com/Ming-H/yinyuan-skills
+  content_lock:
+    locked_ref: b091c8861a148b8260dedfbd06fc10daf7f886fc
+    locked_url: https://github.com/Ming-H/yinyuan-skills/commit/b091c8861a148b8260dedfbd06fc10daf7f886fc
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: Renhuai123/ziwei-doushu
@@ -38,7 +46,15 @@ locks:
   content_lock:
     locked_ref: 88194a404242bfe5c6d5cc512e4117e3e245cdd5
     locked_url: https://github.com/Renhuai123/ziwei-doushu/commit/88194a404242bfe5c6d5cc512e4117e3e245cdd5
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
+    update_policy: monthly_pr
+    vendored: false
+- repo: Shubham0812/SwiftUI-Animations
+  source_url: https://github.com/Shubham0812/SwiftUI-Animations
+  content_lock:
+    locked_ref: 030bd1c710f9cdcc30b30e3912b361990e473be1
+    locked_url: https://github.com/Shubham0812/SwiftUI-Animations/commit/030bd1c710f9cdcc30b30e3912b361990e473be1
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: SylarLong/iztro
@@ -46,7 +62,7 @@ locks:
   content_lock:
     locked_ref: 814b77e6371e1050cac31bbf674db3c3138fcfde
     locked_url: https://github.com/SylarLong/iztro/commit/814b77e6371e1050cac31bbf674db3c3138fcfde
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: THU-MAIC/OpenMAIC
@@ -54,7 +70,7 @@ locks:
   content_lock:
     locked_ref: 1b4a168175e88057c77869196f7da8ef657fcb2f
     locked_url: https://github.com/THU-MAIC/OpenMAIC/commit/1b4a168175e88057c77869196f7da8ef657fcb2f
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: Usagi-org/ai-goofish-monitor
@@ -62,7 +78,7 @@ locks:
   content_lock:
     locked_ref: f85d140b6b45029d9a0925feb96dad733b41396d
     locked_url: https://github.com/Usagi-org/ai-goofish-monitor/commit/f85d140b6b45029d9a0925feb96dad733b41396d
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: afumu/wetrace-skill
@@ -70,7 +86,7 @@ locks:
   content_lock:
     locked_ref: 6280e9c106a2549340bf750ccae71f4053ed4710
     locked_url: https://github.com/afumu/wetrace-skill/commit/6280e9c106a2549340bf750ccae71f4053ed4710
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: birobirobiro/awesome-shadcn-ui
@@ -78,7 +94,7 @@ locks:
   content_lock:
     locked_ref: 7417bbeae2d214b0991fa49b4a42d2844fa0c54b
     locked_url: https://github.com/birobirobiro/awesome-shadcn-ui/commit/7417bbeae2d214b0991fa49b4a42d2844fa0c54b
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: chenglou/pretext
@@ -86,7 +102,7 @@ locks:
   content_lock:
     locked_ref: ac49b09b7d83ede19581fa94a8b892b07d309baf
     locked_url: https://github.com/chenglou/pretext/commit/ac49b09b7d83ede19581fa94a8b892b07d309baf
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: chenjin-cmd/wechat-miniprogram-builder
@@ -94,7 +110,7 @@ locks:
   content_lock:
     locked_ref: e8bba7855d9209451b2d2b5a9fa17c15b8d42401
     locked_url: https://github.com/chenjin-cmd/wechat-miniprogram-builder/commit/e8bba7855d9209451b2d2b5a9fa17c15b8d42401
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: chuspeeism/dashi-taskboard
@@ -102,7 +118,7 @@ locks:
   content_lock:
     locked_ref: f0f4cabced1b15e47c852438a9a599d245a38063
     locked_url: https://github.com/chuspeeism/dashi-taskboard/commit/f0f4cabced1b15e47c852438a9a599d245a38063
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: curionox/lifekline
@@ -110,7 +126,7 @@ locks:
   content_lock:
     locked_ref: b9a27a71260a09f26a1e3757fbee2ba71f52773b
     locked_url: https://github.com/curionox/lifekline/commit/b9a27a71260a09f26a1e3757fbee2ba71f52773b
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: helloianneo/obsidian-ai-second-brain
@@ -118,7 +134,7 @@ locks:
   content_lock:
     locked_ref: fb3468a1d5facf6f42bcce4db4d161dabd1fd615
     locked_url: https://github.com/helloianneo/obsidian-ai-second-brain/commit/fb3468a1d5facf6f42bcce4db4d161dabd1fd615
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: idootop/open-xiaoai
@@ -126,7 +142,7 @@ locks:
   content_lock:
     locked_ref: bc3396c64e2a435f354eb5cb12a203981f1fe422
     locked_url: https://github.com/idootop/open-xiaoai/commit/bc3396c64e2a435f354eb5cb12a203981f1fe422
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: iptv-org/iptv
@@ -134,7 +150,7 @@ locks:
   content_lock:
     locked_ref: b0390e5c6a48065a7def742421353a6109fd3bbd
     locked_url: https://github.com/iptv-org/iptv/commit/b0390e5c6a48065a7def742421353a6109fd3bbd
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: learnwithu/mingli-master
@@ -142,7 +158,7 @@ locks:
   content_lock:
     locked_ref: 000da99552cdfdbdfde49f6e76b014515b8ea51c
     locked_url: https://github.com/learnwithu/mingli-master/commit/000da99552cdfdbdfde49f6e76b014515b8ea51c
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: miounet11/life-kline
@@ -150,55 +166,7 @@ locks:
   content_lock:
     locked_ref: 7abf184df370452ee8279d72c8b45bc09e19913b
     locked_url: https://github.com/miounet11/life-kline/commit/7abf184df370452ee8279d72c8b45bc09e19913b
-    locked_at: '2026-08-26'
-    update_policy: monthly_pr
-    vendored: false
-- repo: n8n-io/n8n
-  source_url: https://github.com/n8n-io/n8n
-  content_lock:
-    locked_ref: 48c42fa4b8caba99f415b06ca2a3d2090fa46636
-    locked_url: https://github.com/n8n-io/n8n/commit/48c42fa4b8caba99f415b06ca2a3d2090fa46636
-    locked_at: '2026-08-26'
-    update_policy: monthly_pr
-    vendored: false
-- repo: nextlevelbuilder/ui-ux-pro-max-skill
-  source_url: https://github.com/nextlevelbuilder/ui-ux-pro-max-skill
-  content_lock:
-    locked_ref: e353a508767c6d39f0e7698b084dbfc8699fffd3
-    locked_url: https://github.com/nextlevelbuilder/ui-ux-pro-max-skill/commit/e353a508767c6d39f0e7698b084dbfc8699fffd3
-    locked_at: '2026-08-26'
-    update_policy: monthly_pr
-    vendored: false
-- repo: nexu-io/html-anything
-  source_url: https://github.com/nexu-io/html-anything
-  content_lock:
-    locked_ref: c31204544230578ac814026fecc153c6e36587ae
-    locked_url: https://github.com/nexu-io/html-anything/commit/c31204544230578ac814026fecc153c6e36587ae
-    locked_at: '2026-08-26'
-    update_policy: monthly_pr
-    vendored: false
-- repo: nexu-io/open-design
-  source_url: https://github.com/nexu-io/open-design
-  content_lock:
-    locked_ref: f888d72d5f1a6e486bf0448ef171b4e452b1e58f
-    locked_url: https://github.com/nexu-io/open-design/commit/f888d72d5f1a6e486bf0448ef171b4e452b1e58f
-    locked_at: '2026-08-26'
-    update_policy: monthly_pr
-    vendored: false
-- repo: pbakaus/impeccable
-  source_url: https://github.com/pbakaus/impeccable
-  content_lock:
-    locked_ref: fcd7622cd2d8e2b09344ba8ede9fcac82cec4e70
-    locked_url: https://github.com/pbakaus/impeccable/commit/fcd7622cd2d8e2b09344ba8ede9fcac82cec4e70
-    locked_at: '2026-08-26'
-    update_policy: monthly_pr
-    vendored: false
-- repo: phuryn/pm-skills
-  source_url: https://github.com/phuryn/pm-skills
-  content_lock:
-    locked_ref: 18468a95b427e70e258b51389796367c6f684e7d
-    locked_url: https://github.com/phuryn/pm-skills/commit/18468a95b427e70e258b51389796367c6f684e7d
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: zarazhangrui/tab-out
@@ -206,6 +174,6 @@ locks:
   content_lock:
     locked_ref: 2c9b9c5a92d37e2bc1d1f121986f880467e0ef92
     locked_url: https://github.com/zarazhangrui/tab-out/commit/2c9b9c5a92d37e2bc1d1f121986f880467e0ef92
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false

--- a/registry.yaml
+++ b/registry.yaml
@@ -2,6 +2,6 @@ universe: product-lab
 registry_repo: true
 registry_role: public_scoped
 canonical_registry_repo: zinan92/park-operating-system
-canonical_snapshot: github-universe-2026-08-26
-generated_from_checksum: 76ea409b99523b3b5a289cfa07290a8e73d9c13cb9b311ff652395858d379ad1
-export_checksum: 0117ece34f6e29339e08012a8428ecad91ec8ff63bc06c4b507d101c67550d16
+canonical_snapshot: github-universe-2026-08-26-review-01
+generated_from_checksum: 0aade4a0fd73c7283739914f8e1ae0629ba7417296106fb1dcbb346964f24a55
+export_checksum: 78995652a7a2d4bd3cdc29dab7777a0cbdaee1557faeccc87196ad2ea9408977

--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -1,7 +1,7 @@
 universe: product-lab
-snapshot_id: github-universe-2026-08-26
+snapshot_id: github-universe-2026-08-26-review-01
 generated_from: zinan92/park-operating-system
-generated_from_checksum: 76ea409b99523b3b5a289cfa07290a8e73d9c13cb9b311ff652395858d379ad1
+generated_from_checksum: 0aade4a0fd73c7283739914f8e1ae0629ba7417296106fb1dcbb346964f24a55
 entries:
 - universe: product-lab
   repo: 6tail/tyme4ts
@@ -26,12 +26,12 @@ entries:
     archived: false
     description: Tyme是一个非常强大的日历工具库，可以看作 Lunar 的升级版，拥有更优的设计和扩展性，支持公历、农历、藏历、回历、星座、干支、生肖、节气、月相、法定假日等。
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-08-17T09:47:13Z'
   content_lock:
     locked_ref: 9e776099e164c43fd932684875057fe345773241
     locked_url: https://github.com/6tail/tyme4ts/commit/9e776099e164c43fd932684875057fe345773241
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -59,12 +59,12 @@ entries:
     archived: false
     description: 八字、紫微、星盘、六爻、梅花、奇门、大六壬、小六壬、塔罗、雷诺曼、灵签、择日一站式玄学算命占卜工具包，输出结构化提示词与数据。提供公开 API、MCP Server 与 skill。
     license_spdx: NOASSERTION
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-08-25T12:30:06Z'
   content_lock:
     locked_ref: 1272aa0cd83a802e78b61568571f709517a1e369
     locked_url: https://github.com/Brhiza/mingyu/commit/1272aa0cd83a802e78b61568571f709517a1e369
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -90,12 +90,12 @@ entries:
     archived: false
     description: A benchmark for evaluating LLMs on Chinese traditional fortune telling — Bazi (八字) and Ziwei Doushu (紫微斗数).
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-05-09T17:49:34Z'
   content_lock:
     locked_ref: b7433280fd86d7a7c27debbc47d0303c218f0bfd
     locked_url: https://github.com/DestinyLinker/MingLi-Bench/commit/b7433280fd86d7a7c27debbc47d0303c218f0bfd
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -122,12 +122,43 @@ entries:
     archived: false
     description: 'Taste-Skill - gives your AI good taste. stops the AI from generating boring, generic slop '
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-08-24T15:23:56Z'
   content_lock:
     locked_ref: ccbc15639c97057cbfcf32ecebc38ef716e4bb37
     locked_url: https://github.com/Leonxlnx/taste-skill/commit/ccbc15639c97057cbfcf32ecebc38ef716e4bb37
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
+    update_policy: monthly_pr
+    vendored: false
+- universe: product-lab
+  repo: Ming-H/yinyuan-skills
+  owned: false
+  starred: true
+  source_kind: starred
+  registry_repo: false
+  registry_role: null
+  primary_category: product
+  tags:
+  - skill
+  source_url: https://github.com/Ming-H/yinyuan-skills
+  visibility: public
+  archived: false
+  description: yinyuan-skills
+  status: READY
+  review_status: confirmed
+  review_reason: null
+  github_snapshot:
+    default_branch: main
+    visibility: public
+    archived: false
+    description: yinyuan-skills
+    license_spdx: NOASSERTION
+    checked_at: 2026-08-26-review-01
+    pushed_at: '2026-04-05T08:09:38Z'
+  content_lock:
+    locked_ref: b091c8861a148b8260dedfbd06fc10daf7f886fc
+    locked_url: https://github.com/Ming-H/yinyuan-skills/commit/b091c8861a148b8260dedfbd06fc10daf7f886fc
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -153,12 +184,44 @@ entries:
     archived: false
     description: 紫微斗数开源排盘引擎 — 基于倪海夏《天纪》体系，含完整排盘算法、四化系统、格局知识库、古籍原文数据
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-06-24T07:24:36Z'
   content_lock:
     locked_ref: 88194a404242bfe5c6d5cc512e4117e3e245cdd5
     locked_url: https://github.com/Renhuai123/ziwei-doushu/commit/88194a404242bfe5c6d5cc512e4117e3e245cdd5
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
+    update_policy: monthly_pr
+    vendored: false
+- universe: product-lab
+  repo: Shubham0812/SwiftUI-Animations
+  owned: false
+  starred: true
+  source_kind: starred
+  registry_repo: false
+  registry_role: null
+  primary_category: product
+  tags: []
+  source_url: https://github.com/Shubham0812/SwiftUI-Animations
+  visibility: public
+  archived: false
+  description: A repository containing a variety of animations and Animated components created in SwiftUI that you can use
+    in your own projects.
+  status: READY
+  review_status: needs_review
+  review_reason: 'new-star-review: reusable SwiftUI animation components; provisional Product Lab product/library placement.'
+  github_snapshot:
+    default_branch: master
+    visibility: public
+    archived: false
+    description: A repository containing a variety of animations and Animated components created in SwiftUI that you can use
+      in your own projects.
+    license_spdx: Apache-2.0
+    checked_at: 2026-08-26-review-01
+    pushed_at: '2026-08-11T15:20:15Z'
+  content_lock:
+    locked_ref: 030bd1c710f9cdcc30b30e3912b361990e473be1
+    locked_url: https://github.com/Shubham0812/SwiftUI-Animations/commit/030bd1c710f9cdcc30b30e3912b361990e473be1
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -187,12 +250,12 @@ entries:
     description: ⭐This is a lightweight kit for generating astrolabes for Zi Wei Dou Shu (The Purple Star Astrology), an ancient
       Chinese astrology. It allows you to obtain your horoscope and personality analysis. 支持多语言轻量级获取紫微斗数排盘信息的javascript开源库。
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-08-19T15:46:01Z'
   content_lock:
     locked_ref: 814b77e6371e1050cac31bbf674db3c3138fcfde
     locked_url: https://github.com/SylarLong/iztro/commit/814b77e6371e1050cac31bbf674db3c3138fcfde
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -219,12 +282,12 @@ entries:
     archived: false
     description: Open Multi-Agent Interactive Classroom — Get an immersive, multi-agent learning experience in just one click
     license_spdx: MIT
-    checked_at: '2026-08-26'
-    pushed_at: '2026-08-26T03:03:18Z'
+    checked_at: 2026-08-26-review-01
+    pushed_at: '2026-08-26T08:34:51Z'
   content_lock:
     locked_ref: 1b4a168175e88057c77869196f7da8ef657fcb2f
     locked_url: https://github.com/THU-MAIC/OpenMAIC/commit/1b4a168175e88057c77869196f7da8ef657fcb2f
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -252,12 +315,12 @@ entries:
     archived: true
     description: 基于 Playwright 和AI实现的闲鱼多任务实时/定时监控与智能分析系统，配备了功能完善的后台管理UI。帮助用户从闲鱼海量商品中，找到心仪产品。
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-05-18T10:52:34Z'
   content_lock:
     locked_ref: f85d140b6b45029d9a0925feb96dad733b41396d
     locked_url: https://github.com/Usagi-org/ai-goofish-monitor/commit/f85d140b6b45029d9a0925feb96dad733b41396d
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -284,12 +347,12 @@ entries:
     archived: false
     description: 微信聊天记录skill
     license_spdx: NOASSERTION
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-02-14T08:51:02Z'
   content_lock:
     locked_ref: 6280e9c106a2549340bf750ccae71f4053ed4710
     locked_url: https://github.com/afumu/wetrace-skill/commit/6280e9c106a2549340bf750ccae71f4053ed4710
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -316,12 +379,12 @@ entries:
     archived: false
     description: A curated list of awesome things related to shadcn/ui.
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-08-24T03:57:40Z'
   content_lock:
     locked_ref: 7417bbeae2d214b0991fa49b4a42d2844fa0c54b
     locked_url: https://github.com/birobirobiro/awesome-shadcn-ui/commit/7417bbeae2d214b0991fa49b4a42d2844fa0c54b
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -347,12 +410,12 @@ entries:
     archived: false
     description: Fast, accurate & comprehensive text measurement & layout
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-06-23T05:01:09Z'
   content_lock:
     locked_ref: ac49b09b7d83ede19581fa94a8b892b07d309baf
     locked_url: https://github.com/chenglou/pretext/commit/ac49b09b7d83ede19581fa94a8b892b07d309baf
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -377,12 +440,12 @@ entries:
     archived: false
     description: wechat-miniprogram-builder
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-08-01T15:58:29Z'
   content_lock:
     locked_ref: e8bba7855d9209451b2d2b5a9fa17c15b8d42401
     locked_url: https://github.com/chenjin-cmd/wechat-miniprogram-builder/commit/e8bba7855d9209451b2d2b5a9fa17c15b8d42401
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -408,12 +471,12 @@ entries:
     archived: false
     description: ''
     license_spdx: Apache-2.0
-    checked_at: '2026-08-26'
-    pushed_at: '2026-08-25T20:21:18Z'
+    checked_at: 2026-08-26-review-01
+    pushed_at: '2026-08-26T08:47:33Z'
   content_lock:
     locked_ref: f0f4cabced1b15e47c852438a9a599d245a38063
     locked_url: https://github.com/chuspeeism/dashi-taskboard/commit/f0f4cabced1b15e47c852438a9a599d245a38063
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -438,12 +501,12 @@ entries:
     archived: false
     description: 人生K线 - 基于AI的八字命理可视化工具
     license_spdx: NOASSERTION
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2025-12-14T13:09:01Z'
   content_lock:
     locked_ref: b9a27a71260a09f26a1e3757fbee2ba71f52773b
     locked_url: https://github.com/curionox/lifekline/commit/b9a27a71260a09f26a1e3757fbee2ba71f52773b
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -469,12 +532,12 @@ entries:
     archived: false
     description: Obsidian + Claude AI 个人知识库完整搭建指南 | 基于 Karpathy LLM Wiki 方法论 | 4 阶段 12 步 | 不用写代码
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-04-13T09:34:10Z'
   content_lock:
     locked_ref: fb3468a1d5facf6f42bcce4db4d161dabd1fd615
     locked_url: https://github.com/helloianneo/obsidian-ai-second-brain/commit/fb3468a1d5facf6f42bcce4db4d161dabd1fd615
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -501,12 +564,12 @@ entries:
     archived: true
     description: '🔊 让小爱音箱「听见你的声音」，解锁无限可能。 '
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-04-04T07:58:12Z'
   content_lock:
     locked_ref: bc3396c64e2a435f354eb5cb12a203981f1fe422
     locked_url: https://github.com/idootop/open-xiaoai/commit/bc3396c64e2a435f354eb5cb12a203981f1fe422
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -533,12 +596,12 @@ entries:
     archived: false
     description: Collection of publicly available IPTV channels from all over the world
     license_spdx: Unlicense
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-08-26T00:09:32Z'
   content_lock:
     locked_ref: b0390e5c6a48065a7def742421353a6109fd3bbd
     locked_url: https://github.com/iptv-org/iptv/commit/b0390e5c6a48065a7def742421353a6109fd3bbd
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -565,12 +628,12 @@ entries:
     archived: false
     description: 紫微斗数命盘解读 skill · 基于 iztro-py 精确排盘，生成可视化命盘 HTML
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-08-15T12:51:17Z'
   content_lock:
     locked_ref: 000da99552cdfdbdfde49f6e76b014515b8ea51c
     locked_url: https://github.com/learnwithu/mingli-master/commit/000da99552cdfdbdfde49f6e76b014515b8ea51c
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -596,225 +659,12 @@ entries:
     archived: false
     description: 🌟 人生K线 - 基于 AI 大模型 + 传统八字命理的人生运势可视化工具。将命运绘制成 K 线图，像看股票一样看人生！支持自托管部署。
     license_spdx: Apache-2.0
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2025-12-22T09:41:30Z'
   content_lock:
     locked_ref: 7abf184df370452ee8279d72c8b45bc09e19913b
     locked_url: https://github.com/miounet11/life-kline/commit/7abf184df370452ee8279d72c8b45bc09e19913b
-    locked_at: '2026-08-26'
-    update_policy: monthly_pr
-    vendored: false
-- universe: product-lab
-  repo: n8n-io/n8n
-  owned: false
-  starred: true
-  source_kind: starred
-  registry_repo: false
-  registry_role: null
-  primary_category: product
-  tags:
-  - product
-  - typescript
-  - workflow
-  source_url: https://github.com/n8n-io/n8n
-  visibility: public
-  archived: false
-  description: Fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code,
-    self-host or cloud, 400+ integrations.
-  status: READY
-  review_status: confirmed
-  review_reason: null
-  github_snapshot:
-    default_branch: master
-    visibility: public
-    archived: false
-    description: Fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code,
-      self-host or cloud, 400+ integrations.
-    license_spdx: NOASSERTION
-    checked_at: '2026-08-26'
-    pushed_at: '2026-08-25T23:55:55Z'
-  content_lock:
-    locked_ref: 48c42fa4b8caba99f415b06ca2a3d2090fa46636
-    locked_url: https://github.com/n8n-io/n8n/commit/48c42fa4b8caba99f415b06ca2a3d2090fa46636
-    locked_at: '2026-08-26'
-    update_policy: monthly_pr
-    vendored: false
-- universe: product-lab
-  repo: nextlevelbuilder/ui-ux-pro-max-skill
-  owned: false
-  starred: true
-  source_kind: starred
-  registry_repo: false
-  registry_role: null
-  primary_category: product
-  tags:
-  - image
-  - product
-  - python
-  - skill
-  source_url: https://github.com/nextlevelbuilder/ui-ux-pro-max-skill
-  visibility: public
-  archived: false
-  description: An AI skill that provides design intelligence for building professional UI/UX across multiple platforms.
-  status: READY
-  review_status: confirmed
-  review_reason: null
-  github_snapshot:
-    default_branch: main
-    visibility: public
-    archived: false
-    description: An AI skill that provides design intelligence for building professional UI/UX across multiple platforms.
-    license_spdx: MIT
-    checked_at: '2026-08-26'
-    pushed_at: '2026-08-25T15:27:04Z'
-  content_lock:
-    locked_ref: e353a508767c6d39f0e7698b084dbfc8699fffd3
-    locked_url: https://github.com/nextlevelbuilder/ui-ux-pro-max-skill/commit/e353a508767c6d39f0e7698b084dbfc8699fffd3
-    locked_at: '2026-08-26'
-    update_policy: monthly_pr
-    vendored: false
-- universe: product-lab
-  repo: nexu-io/html-anything
-  owned: false
-  starred: true
-  source_kind: starred
-  registry_repo: false
-  registry_role: null
-  primary_category: product
-  tags:
-  - api
-  - skill
-  source_url: https://github.com/nexu-io/html-anything
-  visibility: public
-  archived: false
-  description: ✨ The agentic HTML editor — your local AI agent writes the HTML, you ship it. 🚀 75 Skills × 9 Surfaces (magazine
-    · deck · poster · XHS / tweet · prototype · data report · Hyperframes) 🛡️ Sandboxed preview · 📤 1-click to WeChat / X
-    / Zhihu / HTML / PNG 🔑 Zero API key — Claude Code / Cursor / Codex / Gemini / Copilot / OpenCode / Qwen / Aider.
-  status: READY
-  review_status: confirmed
-  review_reason: null
-  github_snapshot:
-    default_branch: main
-    visibility: public
-    archived: false
-    description: ✨ The agentic HTML editor — your local AI agent writes the HTML, you ship it. 🚀 75 Skills × 9 Surfaces (magazine
-      · deck · poster · XHS / tweet · prototype · data report · Hyperframes) 🛡️ Sandboxed preview · 📤 1-click to WeChat /
-      X / Zhihu / HTML / PNG 🔑 Zero API key — Claude Code / Cursor / Codex / Gemini / Copilot / OpenCode / Qwen / Aider.
-    license_spdx: Apache-2.0
-    checked_at: '2026-08-26'
-    pushed_at: '2026-08-23T08:53:57Z'
-  content_lock:
-    locked_ref: c31204544230578ac814026fecc153c6e36587ae
-    locked_url: https://github.com/nexu-io/html-anything/commit/c31204544230578ac814026fecc153c6e36587ae
-    locked_at: '2026-08-26'
-    update_policy: monthly_pr
-    vendored: false
-- universe: product-lab
-  repo: nexu-io/open-design
-  owned: false
-  starred: true
-  source_kind: starred
-  registry_repo: false
-  registry_role: null
-  primary_category: product
-  tags:
-  - dashboard
-  - image
-  - product
-  - skill
-  - typescript
-  - video
-  source_url: https://github.com/nexu-io/open-design
-  visibility: public
-  archived: false
-  description: '🎨 Best DeepSeek Harness Design Plugin. The open-source Claude Design alternative. 🖥️ Local-first desktop app.
-    🖼️ Your coding agent becomes the design engine: prototypes, landing pages, dashboards, slides, images & video — real files,
-    HTML/PDF/PPTX/MP4 export. 🤖 Claude Code / Codex / Cursor / DeepSeek Harness / OpenCode & 20+ CLIs via BYOK.'
-  status: READY
-  review_status: confirmed
-  review_reason: null
-  github_snapshot:
-    default_branch: main
-    visibility: public
-    archived: false
-    description: '🎨 Best DeepSeek Harness Design Plugin. The open-source Claude Design alternative. 🖥️ Local-first desktop
-      app. 🖼️ Your coding agent becomes the design engine: prototypes, landing pages, dashboards, slides, images & video —
-      real files, HTML/PDF/PPTX/MP4 export. 🤖 Claude Code / Codex / Cursor / DeepSeek Harness / OpenCode & 20+ CLIs via BYOK.'
-    license_spdx: Apache-2.0
-    checked_at: '2026-08-26'
-    pushed_at: '2026-08-26T02:48:47Z'
-  content_lock:
-    locked_ref: f888d72d5f1a6e486bf0448ef171b4e452b1e58f
-    locked_url: https://github.com/nexu-io/open-design/commit/f888d72d5f1a6e486bf0448ef171b4e452b1e58f
-    locked_at: '2026-08-26'
-    update_policy: monthly_pr
-    vendored: false
-- universe: product-lab
-  repo: pbakaus/impeccable
-  owned: false
-  starred: true
-  source_kind: starred
-  registry_repo: false
-  registry_role: null
-  primary_category: product
-  tags:
-  - image
-  - javascript
-  source_url: https://github.com/pbakaus/impeccable
-  visibility: public
-  archived: false
-  description: The design language that makes your AI harness better at design.
-  status: READY
-  review_status: confirmed
-  review_reason: null
-  github_snapshot:
-    default_branch: main
-    visibility: public
-    archived: false
-    description: The design language that makes your AI harness better at design.
-    license_spdx: Apache-2.0
-    checked_at: '2026-08-26'
-    pushed_at: '2026-08-25T19:07:13Z'
-  content_lock:
-    locked_ref: fcd7622cd2d8e2b09344ba8ede9fcac82cec4e70
-    locked_url: https://github.com/pbakaus/impeccable/commit/fcd7622cd2d8e2b09344ba8ede9fcac82cec4e70
-    locked_at: '2026-08-26'
-    update_policy: monthly_pr
-    vendored: false
-- universe: product-lab
-  repo: phuryn/pm-skills
-  owned: false
-  starred: true
-  source_kind: starred
-  registry_repo: false
-  registry_role: null
-  primary_category: product
-  tags:
-  - image
-  - research
-  - skill
-  - video
-  source_url: https://github.com/phuryn/pm-skills
-  visibility: public
-  archived: false
-  description: 'PM Skills Marketplace: 100+ agentic skills, commands, and plugins — from discovery to strategy, execution,
-    launch, and growth.'
-  status: READY
-  review_status: confirmed
-  review_reason: null
-  github_snapshot:
-    default_branch: main
-    visibility: public
-    archived: false
-    description: 'PM Skills Marketplace: 100+ agentic skills, commands, and plugins — from discovery to strategy, execution,
-      launch, and growth.'
-    license_spdx: MIT
-    checked_at: '2026-08-26'
-    pushed_at: '2026-07-03T11:34:49Z'
-  content_lock:
-    locked_ref: 18468a95b427e70e258b51389796367c6f684e7d
-    locked_url: https://github.com/phuryn/pm-skills/commit/18468a95b427e70e258b51389796367c6f684e7d
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -842,12 +692,12 @@ entries:
     description: 'Keep tabs on your tabs. Turn your "New tabs" page into a mission control, so you can close them easily.
       Built for people who open too many tabs and never close them. '
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-04-14T22:27:23Z'
   content_lock:
     locked_ref: 2c9b9c5a92d37e2bc1d1f121986f880467e0ef92
     locked_url: https://github.com/zarazhangrui/tab-out/commit/2c9b9c5a92d37e2bc1d1f121986f880467e0ef92
-    locked_at: '2026-08-26'
+    locked_at: 2026-08-26-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -873,7 +723,7 @@ entries:
     archived: false
     description: 本地记录 Codex thread 的 token 使用与项目归属。in Codex session JSONL → out daily thread ledger + read-only HTML UI
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-08-04T06:20:07Z'
 - universe: product-lab
   repo: zinan92/life-kline
@@ -899,7 +749,7 @@ entries:
     archived: false
     description: ''
     license_spdx: NOASSERTION
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-07-22T08:47:55Z'
 - universe: product-lab
   repo: zinan92/paileggemai
@@ -925,7 +775,7 @@ entries:
     archived: false
     description: 电商商品图生成短视频工作台
     license_spdx: NOASSERTION
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-07-22T12:23:24Z'
 - universe: product-lab
   repo: zinan92/park-builds
@@ -949,7 +799,7 @@ entries:
     archived: false
     description: ''
     license_spdx: NOASSERTION
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-06-04T16:18:27Z'
 - universe: product-lab
   repo: zinan92/proactive-explorer
@@ -976,7 +826,7 @@ entries:
     description: 'Strategic product direction finder for open-source repos — 5 MECE categories: Product Depth, Product Reach,
       Time-to-Value, Trust & Proof, Growth'
     license_spdx: NOASSERTION
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-03-19T06:43:22Z'
 - universe: product-lab
   repo: zinan92/repo-evals
@@ -1001,7 +851,7 @@ entries:
     archived: false
     description: Claim-first repo 评测框架。in target repo + claim map → out bilingual verdict dossier + all-evals dashboard
     license_spdx: MIT
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-07-09T15:41:46Z'
 - universe: product-lab
   repo: zinan92/tokenpulse
@@ -1029,7 +879,7 @@ entries:
     description: 把 Claude/Codex 本地 token 日志变成桌面鞭策 widget、Telegram 推送、CLI 状态和可分享 QR 战绩卡。in 本地日志 + models.dev → out goad widget
       + share card
     license_spdx: NOASSERTION
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-07-28T16:01:13Z'
 - universe: product-lab
   repo: zinan92/tokenrouter
@@ -1055,7 +905,7 @@ entries:
     archived: true
     description: 个人项目组合工作台：双通道成本账本 + TokenRouter v0 级联内核
     license_spdx: NOASSERTION
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-08-02T08:59:59Z'
 - universe: product-lab
   repo: zinan92/wcstubhub-clone
@@ -1081,7 +931,7 @@ entries:
     archived: true
     description: 移动优先的票务市场平台 — FIFA 2026 主题，信任架构，智能定价，完整交易流程
     license_spdx: NOASSERTION
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-03-27T14:18:50Z'
 - universe: product-lab
   repo: zinan92/wechat-customer-pipeline
@@ -1108,7 +958,7 @@ entries:
     archived: false
     description: 把授权的本机微信数据库转成私有客户管道与关系行动快照。in WeChat 数据 + 迁移确认 → out HTML + CSV + A/B/C/D + actions + receipts
     license_spdx: NOASSERTION
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-08-07T10:11:39Z'
 - universe: product-lab
   repo: zinan92/wechat-xingqiu
@@ -1134,6 +984,6 @@ entries:
     archived: false
     description: wechat-xingqiu：原生微信会员内容小程序
     license_spdx: NOASSERTION
-    checked_at: '2026-08-26'
+    checked_at: 2026-08-26-review-01
     pushed_at: '2026-08-24T18:24:36Z'
-export_checksum: 0117ece34f6e29339e08012a8428ecad91ec8ff63bc06c4b507d101c67550d16
+export_checksum: 78995652a7a2d4bd3cdc29dab7777a0cbdaee1557faeccc87196ad2ea9408977


### PR DESCRIPTION
## What

- Sync Product Lab to `github-universe-2026-08-26-review-01`.
- Move `Ming-H/yinyuan-skills` into Product Lab.
- Move n8n, UI UX Pro Max, HTML Anything, Open Design, Impeccable and PM Skills out to Agent.
- Rebuild the README with the active mature-product catalog.

## Why

Park clarified that these six are general Agent tools/skills, while Yinyuan belongs with Product Lab.

## Validation

- `bash scripts/verify-scoped.sh` — PASS (33 entries)
- `git diff --check` — PASS
- `gitleaks` — PASS

Canonical authority: https://github.com/zinan92/park-operating-system/pull/61