### PR TITLE
chore: align product registry with review-02

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ fail private source inaccessible → preserve name/link and mark PRIVATE
 fail unclassified placement → keep needs_review; do not guess
 ```
 
-Snapshot: `github-universe-2026-08-26-review-01` · canonical source: [Park OS](https://github.com/zinan92/park-operating-system)
+Snapshot: `github-universe-2026-08-26-review-02` · canonical source: [Park OS](https://github.com/zinan92/park-operating-system)
 
 ## How to read this page
 

--- a/entries/archived.yaml
+++ b/entries/archived.yaml
@@ -1,4 +1,4 @@
-snapshot_id: github-universe-2026-08-26-review-01
+snapshot_id: github-universe-2026-08-26-review-02
 entries:
 - universe: product-lab
   repo: Usagi-org/ai-goofish-monitor
@@ -25,12 +25,12 @@ entries:
     archived: true
     description: 基于 Playwright 和AI实现的闲鱼多任务实时/定时监控与智能分析系统，配备了功能完善的后台管理UI。帮助用户从闲鱼海量商品中，找到心仪产品。
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-05-18T10:52:34Z'
   content_lock:
     locked_ref: f85d140b6b45029d9a0925feb96dad733b41396d
     locked_url: https://github.com/Usagi-org/ai-goofish-monitor/commit/f85d140b6b45029d9a0925feb96dad733b41396d
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -57,12 +57,12 @@ entries:
     archived: true
     description: '🔊 让小爱音箱「听见你的声音」，解锁无限可能。 '
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-04-04T07:58:12Z'
   content_lock:
     locked_ref: bc3396c64e2a435f354eb5cb12a203981f1fe422
     locked_url: https://github.com/idootop/open-xiaoai/commit/bc3396c64e2a435f354eb5cb12a203981f1fe422
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -91,7 +91,7 @@ entries:
     description: 把 Claude/Codex 本地 token 日志变成桌面鞭策 widget、Telegram 推送、CLI 状态和可分享 QR 战绩卡。in 本地日志 + models.dev → out goad widget
       + share card
     license_spdx: NOASSERTION
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-07-28T16:01:13Z'
 - universe: product-lab
   repo: zinan92/tokenrouter
@@ -117,7 +117,7 @@ entries:
     archived: true
     description: 个人项目组合工作台：双通道成本账本 + TokenRouter v0 级联内核
     license_spdx: NOASSERTION
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-02T08:59:59Z'
 - universe: product-lab
   repo: zinan92/wcstubhub-clone
@@ -143,5 +143,5 @@ entries:
     archived: true
     description: 移动优先的票务市场平台 — FIFA 2026 主题，信任架构，智能定价，完整交易流程
     license_spdx: NOASSERTION
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-03-27T14:18:50Z'

--- a/entries/owned.yaml
+++ b/entries/owned.yaml
@@ -1,4 +1,4 @@
-snapshot_id: github-universe-2026-08-26-review-01
+snapshot_id: github-universe-2026-08-26-review-02
 entries:
 - universe: product-lab
   repo: zinan92/codex-harness
@@ -23,7 +23,7 @@ entries:
     archived: false
     description: 本地记录 Codex thread 的 token 使用与项目归属。in Codex session JSONL → out daily thread ledger + read-only HTML UI
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-04T06:20:07Z'
 - universe: product-lab
   repo: zinan92/life-kline
@@ -49,7 +49,7 @@ entries:
     archived: false
     description: ''
     license_spdx: NOASSERTION
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-07-22T08:47:55Z'
 - universe: product-lab
   repo: zinan92/paileggemai
@@ -75,7 +75,7 @@ entries:
     archived: false
     description: 电商商品图生成短视频工作台
     license_spdx: NOASSERTION
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-07-22T12:23:24Z'
 - universe: product-lab
   repo: zinan92/park-builds
@@ -99,7 +99,7 @@ entries:
     archived: false
     description: ''
     license_spdx: NOASSERTION
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-06-04T16:18:27Z'
 - universe: product-lab
   repo: zinan92/proactive-explorer
@@ -126,7 +126,7 @@ entries:
     description: 'Strategic product direction finder for open-source repos — 5 MECE categories: Product Depth, Product Reach,
       Time-to-Value, Trust & Proof, Growth'
     license_spdx: NOASSERTION
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-03-19T06:43:22Z'
 - universe: product-lab
   repo: zinan92/repo-evals
@@ -151,7 +151,7 @@ entries:
     archived: false
     description: Claim-first repo 评测框架。in target repo + claim map → out bilingual verdict dossier + all-evals dashboard
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-07-09T15:41:46Z'
 - universe: product-lab
   repo: zinan92/wechat-customer-pipeline
@@ -178,7 +178,7 @@ entries:
     archived: false
     description: 把授权的本机微信数据库转成私有客户管道与关系行动快照。in WeChat 数据 + 迁移确认 → out HTML + CSV + A/B/C/D + actions + receipts
     license_spdx: NOASSERTION
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-07T10:11:39Z'
 - universe: product-lab
   repo: zinan92/wechat-xingqiu
@@ -204,5 +204,5 @@ entries:
     archived: false
     description: wechat-xingqiu：原生微信会员内容小程序
     license_spdx: NOASSERTION
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-24T18:24:36Z'

--- a/entries/starred.yaml
+++ b/entries/starred.yaml
@@ -1,4 +1,4 @@
-snapshot_id: github-universe-2026-08-26-review-01
+snapshot_id: github-universe-2026-08-26-review-02
 entries:
 - universe: product-lab
   repo: 6tail/tyme4ts
@@ -23,12 +23,12 @@ entries:
     archived: false
     description: Tyme是一个非常强大的日历工具库，可以看作 Lunar 的升级版，拥有更优的设计和扩展性，支持公历、农历、藏历、回历、星座、干支、生肖、节气、月相、法定假日等。
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-17T09:47:13Z'
   content_lock:
     locked_ref: 9e776099e164c43fd932684875057fe345773241
     locked_url: https://github.com/6tail/tyme4ts/commit/9e776099e164c43fd932684875057fe345773241
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -56,12 +56,12 @@ entries:
     archived: false
     description: 八字、紫微、星盘、六爻、梅花、奇门、大六壬、小六壬、塔罗、雷诺曼、灵签、择日一站式玄学算命占卜工具包，输出结构化提示词与数据。提供公开 API、MCP Server 与 skill。
     license_spdx: NOASSERTION
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-25T12:30:06Z'
   content_lock:
     locked_ref: 1272aa0cd83a802e78b61568571f709517a1e369
     locked_url: https://github.com/Brhiza/mingyu/commit/1272aa0cd83a802e78b61568571f709517a1e369
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -87,12 +87,12 @@ entries:
     archived: false
     description: A benchmark for evaluating LLMs on Chinese traditional fortune telling — Bazi (八字) and Ziwei Doushu (紫微斗数).
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-05-09T17:49:34Z'
   content_lock:
     locked_ref: b7433280fd86d7a7c27debbc47d0303c218f0bfd
     locked_url: https://github.com/DestinyLinker/MingLi-Bench/commit/b7433280fd86d7a7c27debbc47d0303c218f0bfd
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -119,12 +119,12 @@ entries:
     archived: false
     description: 'Taste-Skill - gives your AI good taste. stops the AI from generating boring, generic slop '
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-24T15:23:56Z'
   content_lock:
     locked_ref: ccbc15639c97057cbfcf32ecebc38ef716e4bb37
     locked_url: https://github.com/Leonxlnx/taste-skill/commit/ccbc15639c97057cbfcf32ecebc38ef716e4bb37
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -150,12 +150,12 @@ entries:
     archived: false
     description: yinyuan-skills
     license_spdx: NOASSERTION
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-04-05T08:09:38Z'
   content_lock:
     locked_ref: b091c8861a148b8260dedfbd06fc10daf7f886fc
     locked_url: https://github.com/Ming-H/yinyuan-skills/commit/b091c8861a148b8260dedfbd06fc10daf7f886fc
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -181,12 +181,12 @@ entries:
     archived: false
     description: 紫微斗数开源排盘引擎 — 基于倪海夏《天纪》体系，含完整排盘算法、四化系统、格局知识库、古籍原文数据
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-06-24T07:24:36Z'
   content_lock:
     locked_ref: 88194a404242bfe5c6d5cc512e4117e3e245cdd5
     locked_url: https://github.com/Renhuai123/ziwei-doushu/commit/88194a404242bfe5c6d5cc512e4117e3e245cdd5
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -213,12 +213,12 @@ entries:
     description: A repository containing a variety of animations and Animated components created in SwiftUI that you can use
       in your own projects.
     license_spdx: Apache-2.0
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-11T15:20:15Z'
   content_lock:
     locked_ref: 030bd1c710f9cdcc30b30e3912b361990e473be1
     locked_url: https://github.com/Shubham0812/SwiftUI-Animations/commit/030bd1c710f9cdcc30b30e3912b361990e473be1
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -247,12 +247,12 @@ entries:
     description: ⭐This is a lightweight kit for generating astrolabes for Zi Wei Dou Shu (The Purple Star Astrology), an ancient
       Chinese astrology. It allows you to obtain your horoscope and personality analysis. 支持多语言轻量级获取紫微斗数排盘信息的javascript开源库。
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-19T15:46:01Z'
   content_lock:
     locked_ref: 814b77e6371e1050cac31bbf674db3c3138fcfde
     locked_url: https://github.com/SylarLong/iztro/commit/814b77e6371e1050cac31bbf674db3c3138fcfde
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -279,12 +279,12 @@ entries:
     archived: false
     description: Open Multi-Agent Interactive Classroom — Get an immersive, multi-agent learning experience in just one click
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-26T08:34:51Z'
   content_lock:
     locked_ref: 1b4a168175e88057c77869196f7da8ef657fcb2f
     locked_url: https://github.com/THU-MAIC/OpenMAIC/commit/1b4a168175e88057c77869196f7da8ef657fcb2f
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -311,12 +311,12 @@ entries:
     archived: false
     description: 微信聊天记录skill
     license_spdx: NOASSERTION
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-02-14T08:51:02Z'
   content_lock:
     locked_ref: 6280e9c106a2549340bf750ccae71f4053ed4710
     locked_url: https://github.com/afumu/wetrace-skill/commit/6280e9c106a2549340bf750ccae71f4053ed4710
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -343,12 +343,12 @@ entries:
     archived: false
     description: A curated list of awesome things related to shadcn/ui.
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-24T03:57:40Z'
   content_lock:
     locked_ref: 7417bbeae2d214b0991fa49b4a42d2844fa0c54b
     locked_url: https://github.com/birobirobiro/awesome-shadcn-ui/commit/7417bbeae2d214b0991fa49b4a42d2844fa0c54b
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -374,12 +374,12 @@ entries:
     archived: false
     description: Fast, accurate & comprehensive text measurement & layout
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-06-23T05:01:09Z'
   content_lock:
     locked_ref: ac49b09b7d83ede19581fa94a8b892b07d309baf
     locked_url: https://github.com/chenglou/pretext/commit/ac49b09b7d83ede19581fa94a8b892b07d309baf
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -404,12 +404,12 @@ entries:
     archived: false
     description: wechat-miniprogram-builder
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-01T15:58:29Z'
   content_lock:
     locked_ref: e8bba7855d9209451b2d2b5a9fa17c15b8d42401
     locked_url: https://github.com/chenjin-cmd/wechat-miniprogram-builder/commit/e8bba7855d9209451b2d2b5a9fa17c15b8d42401
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -435,12 +435,12 @@ entries:
     archived: false
     description: ''
     license_spdx: Apache-2.0
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-26T08:47:33Z'
   content_lock:
     locked_ref: f0f4cabced1b15e47c852438a9a599d245a38063
     locked_url: https://github.com/chuspeeism/dashi-taskboard/commit/f0f4cabced1b15e47c852438a9a599d245a38063
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -465,12 +465,12 @@ entries:
     archived: false
     description: 人生K线 - 基于AI的八字命理可视化工具
     license_spdx: NOASSERTION
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2025-12-14T13:09:01Z'
   content_lock:
     locked_ref: b9a27a71260a09f26a1e3757fbee2ba71f52773b
     locked_url: https://github.com/curionox/lifekline/commit/b9a27a71260a09f26a1e3757fbee2ba71f52773b
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -496,12 +496,12 @@ entries:
     archived: false
     description: Obsidian + Claude AI 个人知识库完整搭建指南 | 基于 Karpathy LLM Wiki 方法论 | 4 阶段 12 步 | 不用写代码
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-04-13T09:34:10Z'
   content_lock:
     locked_ref: fb3468a1d5facf6f42bcce4db4d161dabd1fd615
     locked_url: https://github.com/helloianneo/obsidian-ai-second-brain/commit/fb3468a1d5facf6f42bcce4db4d161dabd1fd615
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -528,12 +528,12 @@ entries:
     archived: false
     description: Collection of publicly available IPTV channels from all over the world
     license_spdx: Unlicense
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-26T00:09:32Z'
   content_lock:
     locked_ref: b0390e5c6a48065a7def742421353a6109fd3bbd
     locked_url: https://github.com/iptv-org/iptv/commit/b0390e5c6a48065a7def742421353a6109fd3bbd
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -560,12 +560,12 @@ entries:
     archived: false
     description: 紫微斗数命盘解读 skill · 基于 iztro-py 精确排盘，生成可视化命盘 HTML
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-15T12:51:17Z'
   content_lock:
     locked_ref: 000da99552cdfdbdfde49f6e76b014515b8ea51c
     locked_url: https://github.com/learnwithu/mingli-master/commit/000da99552cdfdbdfde49f6e76b014515b8ea51c
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -591,12 +591,12 @@ entries:
     archived: false
     description: 🌟 人生K线 - 基于 AI 大模型 + 传统八字命理的人生运势可视化工具。将命运绘制成 K 线图，像看股票一样看人生！支持自托管部署。
     license_spdx: Apache-2.0
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2025-12-22T09:41:30Z'
   content_lock:
     locked_ref: 7abf184df370452ee8279d72c8b45bc09e19913b
     locked_url: https://github.com/miounet11/life-kline/commit/7abf184df370452ee8279d72c8b45bc09e19913b
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -624,11 +624,11 @@ entries:
     description: 'Keep tabs on your tabs. Turn your "New tabs" page into a mission control, so you can close them easily.
       Built for people who open too many tabs and never close them. '
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-04-14T22:27:23Z'
   content_lock:
     locked_ref: 2c9b9c5a92d37e2bc1d1f121986f880467e0ef92
     locked_url: https://github.com/zarazhangrui/tab-out/commit/2c9b9c5a92d37e2bc1d1f121986f880467e0ef92
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false

--- a/locks/sources.lock.yaml
+++ b/locks/sources.lock.yaml
@@ -1,12 +1,12 @@
-snapshot_id: github-universe-2026-08-26-review-01
-generated_from_checksum: 0aade4a0fd73c7283739914f8e1ae0629ba7417296106fb1dcbb346964f24a55
+snapshot_id: github-universe-2026-08-26-review-02
+generated_from_checksum: 79f85a19d14d59606808cdaf813844924f9e4915272386120ed99af5c0bc6810
 locks:
 - repo: 6tail/tyme4ts
   source_url: https://github.com/6tail/tyme4ts
   content_lock:
     locked_ref: 9e776099e164c43fd932684875057fe345773241
     locked_url: https://github.com/6tail/tyme4ts/commit/9e776099e164c43fd932684875057fe345773241
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - repo: Brhiza/mingyu
@@ -14,7 +14,7 @@ locks:
   content_lock:
     locked_ref: 1272aa0cd83a802e78b61568571f709517a1e369
     locked_url: https://github.com/Brhiza/mingyu/commit/1272aa0cd83a802e78b61568571f709517a1e369
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - repo: DestinyLinker/MingLi-Bench
@@ -22,7 +22,7 @@ locks:
   content_lock:
     locked_ref: b7433280fd86d7a7c27debbc47d0303c218f0bfd
     locked_url: https://github.com/DestinyLinker/MingLi-Bench/commit/b7433280fd86d7a7c27debbc47d0303c218f0bfd
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - repo: Leonxlnx/taste-skill
@@ -30,7 +30,7 @@ locks:
   content_lock:
     locked_ref: ccbc15639c97057cbfcf32ecebc38ef716e4bb37
     locked_url: https://github.com/Leonxlnx/taste-skill/commit/ccbc15639c97057cbfcf32ecebc38ef716e4bb37
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - repo: Ming-H/yinyuan-skills
@@ -38,7 +38,7 @@ locks:
   content_lock:
     locked_ref: b091c8861a148b8260dedfbd06fc10daf7f886fc
     locked_url: https://github.com/Ming-H/yinyuan-skills/commit/b091c8861a148b8260dedfbd06fc10daf7f886fc
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - repo: Renhuai123/ziwei-doushu
@@ -46,7 +46,7 @@ locks:
   content_lock:
     locked_ref: 88194a404242bfe5c6d5cc512e4117e3e245cdd5
     locked_url: https://github.com/Renhuai123/ziwei-doushu/commit/88194a404242bfe5c6d5cc512e4117e3e245cdd5
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - repo: Shubham0812/SwiftUI-Animations
@@ -54,7 +54,7 @@ locks:
   content_lock:
     locked_ref: 030bd1c710f9cdcc30b30e3912b361990e473be1
     locked_url: https://github.com/Shubham0812/SwiftUI-Animations/commit/030bd1c710f9cdcc30b30e3912b361990e473be1
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - repo: SylarLong/iztro
@@ -62,7 +62,7 @@ locks:
   content_lock:
     locked_ref: 814b77e6371e1050cac31bbf674db3c3138fcfde
     locked_url: https://github.com/SylarLong/iztro/commit/814b77e6371e1050cac31bbf674db3c3138fcfde
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - repo: THU-MAIC/OpenMAIC
@@ -70,7 +70,7 @@ locks:
   content_lock:
     locked_ref: 1b4a168175e88057c77869196f7da8ef657fcb2f
     locked_url: https://github.com/THU-MAIC/OpenMAIC/commit/1b4a168175e88057c77869196f7da8ef657fcb2f
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - repo: Usagi-org/ai-goofish-monitor
@@ -78,7 +78,7 @@ locks:
   content_lock:
     locked_ref: f85d140b6b45029d9a0925feb96dad733b41396d
     locked_url: https://github.com/Usagi-org/ai-goofish-monitor/commit/f85d140b6b45029d9a0925feb96dad733b41396d
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - repo: afumu/wetrace-skill
@@ -86,7 +86,7 @@ locks:
   content_lock:
     locked_ref: 6280e9c106a2549340bf750ccae71f4053ed4710
     locked_url: https://github.com/afumu/wetrace-skill/commit/6280e9c106a2549340bf750ccae71f4053ed4710
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - repo: birobirobiro/awesome-shadcn-ui
@@ -94,7 +94,7 @@ locks:
   content_lock:
     locked_ref: 7417bbeae2d214b0991fa49b4a42d2844fa0c54b
     locked_url: https://github.com/birobirobiro/awesome-shadcn-ui/commit/7417bbeae2d214b0991fa49b4a42d2844fa0c54b
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - repo: chenglou/pretext
@@ -102,7 +102,7 @@ locks:
   content_lock:
     locked_ref: ac49b09b7d83ede19581fa94a8b892b07d309baf
     locked_url: https://github.com/chenglou/pretext/commit/ac49b09b7d83ede19581fa94a8b892b07d309baf
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - repo: chenjin-cmd/wechat-miniprogram-builder
@@ -110,7 +110,7 @@ locks:
   content_lock:
     locked_ref: e8bba7855d9209451b2d2b5a9fa17c15b8d42401
     locked_url: https://github.com/chenjin-cmd/wechat-miniprogram-builder/commit/e8bba7855d9209451b2d2b5a9fa17c15b8d42401
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - repo: chuspeeism/dashi-taskboard
@@ -118,7 +118,7 @@ locks:
   content_lock:
     locked_ref: f0f4cabced1b15e47c852438a9a599d245a38063
     locked_url: https://github.com/chuspeeism/dashi-taskboard/commit/f0f4cabced1b15e47c852438a9a599d245a38063
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - repo: curionox/lifekline
@@ -126,7 +126,7 @@ locks:
   content_lock:
     locked_ref: b9a27a71260a09f26a1e3757fbee2ba71f52773b
     locked_url: https://github.com/curionox/lifekline/commit/b9a27a71260a09f26a1e3757fbee2ba71f52773b
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - repo: helloianneo/obsidian-ai-second-brain
@@ -134,7 +134,7 @@ locks:
   content_lock:
     locked_ref: fb3468a1d5facf6f42bcce4db4d161dabd1fd615
     locked_url: https://github.com/helloianneo/obsidian-ai-second-brain/commit/fb3468a1d5facf6f42bcce4db4d161dabd1fd615
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - repo: idootop/open-xiaoai
@@ -142,7 +142,7 @@ locks:
   content_lock:
     locked_ref: bc3396c64e2a435f354eb5cb12a203981f1fe422
     locked_url: https://github.com/idootop/open-xiaoai/commit/bc3396c64e2a435f354eb5cb12a203981f1fe422
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - repo: iptv-org/iptv
@@ -150,7 +150,7 @@ locks:
   content_lock:
     locked_ref: b0390e5c6a48065a7def742421353a6109fd3bbd
     locked_url: https://github.com/iptv-org/iptv/commit/b0390e5c6a48065a7def742421353a6109fd3bbd
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - repo: learnwithu/mingli-master
@@ -158,7 +158,7 @@ locks:
   content_lock:
     locked_ref: 000da99552cdfdbdfde49f6e76b014515b8ea51c
     locked_url: https://github.com/learnwithu/mingli-master/commit/000da99552cdfdbdfde49f6e76b014515b8ea51c
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - repo: miounet11/life-kline
@@ -166,7 +166,7 @@ locks:
   content_lock:
     locked_ref: 7abf184df370452ee8279d72c8b45bc09e19913b
     locked_url: https://github.com/miounet11/life-kline/commit/7abf184df370452ee8279d72c8b45bc09e19913b
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - repo: zarazhangrui/tab-out
@@ -174,6 +174,6 @@ locks:
   content_lock:
     locked_ref: 2c9b9c5a92d37e2bc1d1f121986f880467e0ef92
     locked_url: https://github.com/zarazhangrui/tab-out/commit/2c9b9c5a92d37e2bc1d1f121986f880467e0ef92
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false

--- a/registry.yaml
+++ b/registry.yaml
@@ -2,6 +2,6 @@ universe: product-lab
 registry_repo: true
 registry_role: public_scoped
 canonical_registry_repo: zinan92/park-operating-system
-canonical_snapshot: github-universe-2026-08-26-review-01
-generated_from_checksum: 0aade4a0fd73c7283739914f8e1ae0629ba7417296106fb1dcbb346964f24a55
-export_checksum: 78995652a7a2d4bd3cdc29dab7777a0cbdaee1557faeccc87196ad2ea9408977
+canonical_snapshot: github-universe-2026-08-26-review-02
+generated_from_checksum: 79f85a19d14d59606808cdaf813844924f9e4915272386120ed99af5c0bc6810
+export_checksum: 64b7d7486c41930e4a0e625b17b725fc30c6d2573ee105fdb2e619e9e03751a1

--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -1,7 +1,7 @@
 universe: product-lab
-snapshot_id: github-universe-2026-08-26-review-01
+snapshot_id: github-universe-2026-08-26-review-02
 generated_from: zinan92/park-operating-system
-generated_from_checksum: 0aade4a0fd73c7283739914f8e1ae0629ba7417296106fb1dcbb346964f24a55
+generated_from_checksum: 79f85a19d14d59606808cdaf813844924f9e4915272386120ed99af5c0bc6810
 entries:
 - universe: product-lab
   repo: 6tail/tyme4ts
@@ -26,12 +26,12 @@ entries:
     archived: false
     description: Tyme是一个非常强大的日历工具库，可以看作 Lunar 的升级版，拥有更优的设计和扩展性，支持公历、农历、藏历、回历、星座、干支、生肖、节气、月相、法定假日等。
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-17T09:47:13Z'
   content_lock:
     locked_ref: 9e776099e164c43fd932684875057fe345773241
     locked_url: https://github.com/6tail/tyme4ts/commit/9e776099e164c43fd932684875057fe345773241
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -59,12 +59,12 @@ entries:
     archived: false
     description: 八字、紫微、星盘、六爻、梅花、奇门、大六壬、小六壬、塔罗、雷诺曼、灵签、择日一站式玄学算命占卜工具包，输出结构化提示词与数据。提供公开 API、MCP Server 与 skill。
     license_spdx: NOASSERTION
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-25T12:30:06Z'
   content_lock:
     locked_ref: 1272aa0cd83a802e78b61568571f709517a1e369
     locked_url: https://github.com/Brhiza/mingyu/commit/1272aa0cd83a802e78b61568571f709517a1e369
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -90,12 +90,12 @@ entries:
     archived: false
     description: A benchmark for evaluating LLMs on Chinese traditional fortune telling — Bazi (八字) and Ziwei Doushu (紫微斗数).
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-05-09T17:49:34Z'
   content_lock:
     locked_ref: b7433280fd86d7a7c27debbc47d0303c218f0bfd
     locked_url: https://github.com/DestinyLinker/MingLi-Bench/commit/b7433280fd86d7a7c27debbc47d0303c218f0bfd
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -122,12 +122,12 @@ entries:
     archived: false
     description: 'Taste-Skill - gives your AI good taste. stops the AI from generating boring, generic slop '
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-24T15:23:56Z'
   content_lock:
     locked_ref: ccbc15639c97057cbfcf32ecebc38ef716e4bb37
     locked_url: https://github.com/Leonxlnx/taste-skill/commit/ccbc15639c97057cbfcf32ecebc38ef716e4bb37
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -153,12 +153,12 @@ entries:
     archived: false
     description: yinyuan-skills
     license_spdx: NOASSERTION
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-04-05T08:09:38Z'
   content_lock:
     locked_ref: b091c8861a148b8260dedfbd06fc10daf7f886fc
     locked_url: https://github.com/Ming-H/yinyuan-skills/commit/b091c8861a148b8260dedfbd06fc10daf7f886fc
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -184,12 +184,12 @@ entries:
     archived: false
     description: 紫微斗数开源排盘引擎 — 基于倪海夏《天纪》体系，含完整排盘算法、四化系统、格局知识库、古籍原文数据
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-06-24T07:24:36Z'
   content_lock:
     locked_ref: 88194a404242bfe5c6d5cc512e4117e3e245cdd5
     locked_url: https://github.com/Renhuai123/ziwei-doushu/commit/88194a404242bfe5c6d5cc512e4117e3e245cdd5
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -216,12 +216,12 @@ entries:
     description: A repository containing a variety of animations and Animated components created in SwiftUI that you can use
       in your own projects.
     license_spdx: Apache-2.0
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-11T15:20:15Z'
   content_lock:
     locked_ref: 030bd1c710f9cdcc30b30e3912b361990e473be1
     locked_url: https://github.com/Shubham0812/SwiftUI-Animations/commit/030bd1c710f9cdcc30b30e3912b361990e473be1
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -250,12 +250,12 @@ entries:
     description: ⭐This is a lightweight kit for generating astrolabes for Zi Wei Dou Shu (The Purple Star Astrology), an ancient
       Chinese astrology. It allows you to obtain your horoscope and personality analysis. 支持多语言轻量级获取紫微斗数排盘信息的javascript开源库。
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-19T15:46:01Z'
   content_lock:
     locked_ref: 814b77e6371e1050cac31bbf674db3c3138fcfde
     locked_url: https://github.com/SylarLong/iztro/commit/814b77e6371e1050cac31bbf674db3c3138fcfde
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -282,12 +282,12 @@ entries:
     archived: false
     description: Open Multi-Agent Interactive Classroom — Get an immersive, multi-agent learning experience in just one click
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-26T08:34:51Z'
   content_lock:
     locked_ref: 1b4a168175e88057c77869196f7da8ef657fcb2f
     locked_url: https://github.com/THU-MAIC/OpenMAIC/commit/1b4a168175e88057c77869196f7da8ef657fcb2f
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -315,12 +315,12 @@ entries:
     archived: true
     description: 基于 Playwright 和AI实现的闲鱼多任务实时/定时监控与智能分析系统，配备了功能完善的后台管理UI。帮助用户从闲鱼海量商品中，找到心仪产品。
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-05-18T10:52:34Z'
   content_lock:
     locked_ref: f85d140b6b45029d9a0925feb96dad733b41396d
     locked_url: https://github.com/Usagi-org/ai-goofish-monitor/commit/f85d140b6b45029d9a0925feb96dad733b41396d
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -347,12 +347,12 @@ entries:
     archived: false
     description: 微信聊天记录skill
     license_spdx: NOASSERTION
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-02-14T08:51:02Z'
   content_lock:
     locked_ref: 6280e9c106a2549340bf750ccae71f4053ed4710
     locked_url: https://github.com/afumu/wetrace-skill/commit/6280e9c106a2549340bf750ccae71f4053ed4710
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -379,12 +379,12 @@ entries:
     archived: false
     description: A curated list of awesome things related to shadcn/ui.
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-24T03:57:40Z'
   content_lock:
     locked_ref: 7417bbeae2d214b0991fa49b4a42d2844fa0c54b
     locked_url: https://github.com/birobirobiro/awesome-shadcn-ui/commit/7417bbeae2d214b0991fa49b4a42d2844fa0c54b
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -410,12 +410,12 @@ entries:
     archived: false
     description: Fast, accurate & comprehensive text measurement & layout
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-06-23T05:01:09Z'
   content_lock:
     locked_ref: ac49b09b7d83ede19581fa94a8b892b07d309baf
     locked_url: https://github.com/chenglou/pretext/commit/ac49b09b7d83ede19581fa94a8b892b07d309baf
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -440,12 +440,12 @@ entries:
     archived: false
     description: wechat-miniprogram-builder
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-01T15:58:29Z'
   content_lock:
     locked_ref: e8bba7855d9209451b2d2b5a9fa17c15b8d42401
     locked_url: https://github.com/chenjin-cmd/wechat-miniprogram-builder/commit/e8bba7855d9209451b2d2b5a9fa17c15b8d42401
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -471,12 +471,12 @@ entries:
     archived: false
     description: ''
     license_spdx: Apache-2.0
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-26T08:47:33Z'
   content_lock:
     locked_ref: f0f4cabced1b15e47c852438a9a599d245a38063
     locked_url: https://github.com/chuspeeism/dashi-taskboard/commit/f0f4cabced1b15e47c852438a9a599d245a38063
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -501,12 +501,12 @@ entries:
     archived: false
     description: 人生K线 - 基于AI的八字命理可视化工具
     license_spdx: NOASSERTION
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2025-12-14T13:09:01Z'
   content_lock:
     locked_ref: b9a27a71260a09f26a1e3757fbee2ba71f52773b
     locked_url: https://github.com/curionox/lifekline/commit/b9a27a71260a09f26a1e3757fbee2ba71f52773b
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -532,12 +532,12 @@ entries:
     archived: false
     description: Obsidian + Claude AI 个人知识库完整搭建指南 | 基于 Karpathy LLM Wiki 方法论 | 4 阶段 12 步 | 不用写代码
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-04-13T09:34:10Z'
   content_lock:
     locked_ref: fb3468a1d5facf6f42bcce4db4d161dabd1fd615
     locked_url: https://github.com/helloianneo/obsidian-ai-second-brain/commit/fb3468a1d5facf6f42bcce4db4d161dabd1fd615
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -564,12 +564,12 @@ entries:
     archived: true
     description: '🔊 让小爱音箱「听见你的声音」，解锁无限可能。 '
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-04-04T07:58:12Z'
   content_lock:
     locked_ref: bc3396c64e2a435f354eb5cb12a203981f1fe422
     locked_url: https://github.com/idootop/open-xiaoai/commit/bc3396c64e2a435f354eb5cb12a203981f1fe422
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -596,12 +596,12 @@ entries:
     archived: false
     description: Collection of publicly available IPTV channels from all over the world
     license_spdx: Unlicense
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-26T00:09:32Z'
   content_lock:
     locked_ref: b0390e5c6a48065a7def742421353a6109fd3bbd
     locked_url: https://github.com/iptv-org/iptv/commit/b0390e5c6a48065a7def742421353a6109fd3bbd
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -628,12 +628,12 @@ entries:
     archived: false
     description: 紫微斗数命盘解读 skill · 基于 iztro-py 精确排盘，生成可视化命盘 HTML
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-15T12:51:17Z'
   content_lock:
     locked_ref: 000da99552cdfdbdfde49f6e76b014515b8ea51c
     locked_url: https://github.com/learnwithu/mingli-master/commit/000da99552cdfdbdfde49f6e76b014515b8ea51c
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -659,12 +659,12 @@ entries:
     archived: false
     description: 🌟 人生K线 - 基于 AI 大模型 + 传统八字命理的人生运势可视化工具。将命运绘制成 K 线图，像看股票一样看人生！支持自托管部署。
     license_spdx: Apache-2.0
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2025-12-22T09:41:30Z'
   content_lock:
     locked_ref: 7abf184df370452ee8279d72c8b45bc09e19913b
     locked_url: https://github.com/miounet11/life-kline/commit/7abf184df370452ee8279d72c8b45bc09e19913b
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -692,12 +692,12 @@ entries:
     description: 'Keep tabs on your tabs. Turn your "New tabs" page into a mission control, so you can close them easily.
       Built for people who open too many tabs and never close them. '
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-04-14T22:27:23Z'
   content_lock:
     locked_ref: 2c9b9c5a92d37e2bc1d1f121986f880467e0ef92
     locked_url: https://github.com/zarazhangrui/tab-out/commit/2c9b9c5a92d37e2bc1d1f121986f880467e0ef92
-    locked_at: 2026-08-26-review-01
+    locked_at: 2026-08-26-review-02
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -723,7 +723,7 @@ entries:
     archived: false
     description: 本地记录 Codex thread 的 token 使用与项目归属。in Codex session JSONL → out daily thread ledger + read-only HTML UI
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-04T06:20:07Z'
 - universe: product-lab
   repo: zinan92/life-kline
@@ -749,7 +749,7 @@ entries:
     archived: false
     description: ''
     license_spdx: NOASSERTION
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-07-22T08:47:55Z'
 - universe: product-lab
   repo: zinan92/paileggemai
@@ -775,7 +775,7 @@ entries:
     archived: false
     description: 电商商品图生成短视频工作台
     license_spdx: NOASSERTION
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-07-22T12:23:24Z'
 - universe: product-lab
   repo: zinan92/park-builds
@@ -799,7 +799,7 @@ entries:
     archived: false
     description: ''
     license_spdx: NOASSERTION
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-06-04T16:18:27Z'
 - universe: product-lab
   repo: zinan92/proactive-explorer
@@ -826,7 +826,7 @@ entries:
     description: 'Strategic product direction finder for open-source repos — 5 MECE categories: Product Depth, Product Reach,
       Time-to-Value, Trust & Proof, Growth'
     license_spdx: NOASSERTION
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-03-19T06:43:22Z'
 - universe: product-lab
   repo: zinan92/repo-evals
@@ -851,7 +851,7 @@ entries:
     archived: false
     description: Claim-first repo 评测框架。in target repo + claim map → out bilingual verdict dossier + all-evals dashboard
     license_spdx: MIT
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-07-09T15:41:46Z'
 - universe: product-lab
   repo: zinan92/tokenpulse
@@ -879,7 +879,7 @@ entries:
     description: 把 Claude/Codex 本地 token 日志变成桌面鞭策 widget、Telegram 推送、CLI 状态和可分享 QR 战绩卡。in 本地日志 + models.dev → out goad widget
       + share card
     license_spdx: NOASSERTION
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-07-28T16:01:13Z'
 - universe: product-lab
   repo: zinan92/tokenrouter
@@ -905,7 +905,7 @@ entries:
     archived: true
     description: 个人项目组合工作台：双通道成本账本 + TokenRouter v0 级联内核
     license_spdx: NOASSERTION
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-02T08:59:59Z'
 - universe: product-lab
   repo: zinan92/wcstubhub-clone
@@ -931,7 +931,7 @@ entries:
     archived: true
     description: 移动优先的票务市场平台 — FIFA 2026 主题，信任架构，智能定价，完整交易流程
     license_spdx: NOASSERTION
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-03-27T14:18:50Z'
 - universe: product-lab
   repo: zinan92/wechat-customer-pipeline
@@ -958,7 +958,7 @@ entries:
     archived: false
     description: 把授权的本机微信数据库转成私有客户管道与关系行动快照。in WeChat 数据 + 迁移确认 → out HTML + CSV + A/B/C/D + actions + receipts
     license_spdx: NOASSERTION
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-07T10:11:39Z'
 - universe: product-lab
   repo: zinan92/wechat-xingqiu
@@ -984,6 +984,6 @@ entries:
     archived: false
     description: wechat-xingqiu：原生微信会员内容小程序
     license_spdx: NOASSERTION
-    checked_at: 2026-08-26-review-01
+    checked_at: 2026-08-26-review-02
     pushed_at: '2026-08-24T18:24:36Z'
-export_checksum: 78995652a7a2d4bd3cdc29dab7777a0cbdaee1557faeccc87196ad2ea9408977
+export_checksum: 64b7d7486c41930e4a0e625b17b725fc30c6d2573ee105fdb2e619e9e03751a1


### PR DESCRIPTION
Align generated Product Lab snapshot and README with Park OS review-02. The Product Lab placement set is unchanged in this pointer-only refresh.

Validation: `bash scripts/verify-scoped.sh` PASS (33 entries); `git diff --check` PASS; gitleaks PASS.

Canonical authority: https://github.com/zinan92/park-operating-system/pull/65