### PR TITLE
chore: apply Product Lab removals

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Product Lab 的 capability-first registry：按子分类浏览 owned 与 starred repo。**
 
-[![Snapshot](https://img.shields.io/badge/snapshot-20%20repos-0969DA.svg)](snapshot.yaml)
+[![Snapshot](https://img.shields.io/badge/snapshot-18%20repos-0969DA.svg)](snapshot.yaml)
 [![Source](https://img.shields.io/badge/source-Park%20OS-8250DF.svg)](https://github.com/zinan92/park-operating-system)
 
 </div>
@@ -13,14 +13,14 @@
 
 ```text
 in  canonical Park OS snapshot + source provenance + fixed commit locks
-out 20-repo Product Lab map, grouped by function and owned/starred source
+out 18-repo Product Lab map, grouped by function and owned/starred source
 
 fail snapshot checksum mismatch → stop before publishing
 fail private source inaccessible → preserve name/link and mark PRIVATE
 fail unclassified placement → keep needs_review; do not guess
 ```
 
-Snapshot: `github-universe-2026-08-27-content-review-01` · canonical source: [Park OS](https://github.com/zinan92/park-operating-system)
+Snapshot: `github-universe-2026-08-27-product-park-review-01` · canonical source: [Park OS](https://github.com/zinan92/park-operating-system)
 
 ## How to read this page
 
@@ -53,13 +53,11 @@ Snapshot: `github-universe-2026-08-27-content-review-01` · canonical source: [P
 | [afumu/wetrace-skill](https://github.com/afumu/wetrace-skill) | 微信聊天记录skill | Starred | `6280e9c106a2` |
 | [zinan92/wechat-customer-pipeline](https://github.com/zinan92/wechat-customer-pipeline) | 把授权的本机微信数据库转成私有客户管道与关系行动快照。in WeChat 数据 + 迁移确认 → out HTML + CSV + A/B/C/D + actions + receipts | Owned | owned source · PRIVATE |
 
-### Codex Harness (3)
+### Codex Harness (1)
 
 | Repo | Capability / description | Source | Lock / flags |
 |---|---|---|---|
 | [zinan92/codex-harness](https://github.com/zinan92/codex-harness) | 本地记录 Codex thread 的 token 使用与项目归属。in Codex session JSONL → out daily thread ledger + read-only HTML UI | Owned + Starred | owned source |
-| [zinan92/tokenpulse](https://github.com/zinan92/tokenpulse) | 把 Claude/Codex 本地 token 日志变成桌面鞭策 widget、Telegram 推送、CLI 状态和可分享 QR 战绩卡。in 本地日志 + models.dev → out goad widget + share card | Owned | owned source · ARCHIVED |
-| [zinan92/tokenrouter](https://github.com/zinan92/tokenrouter) | 个人项目组合工作台：双通道成本账本 + TokenRouter v0 级联内核 | Owned | owned source · ARCHIVED |
 
 ### E-commerce / Product Media (2)
 

--- a/entries/archived.yaml
+++ b/entries/archived.yaml
@@ -1,4 +1,4 @@
-snapshot_id: github-universe-2026-08-27-content-review-01
+snapshot_id: github-universe-2026-08-27-product-park-review-01
 entries:
 - universe: product-lab
   repo: Usagi-org/ai-goofish-monitor
@@ -25,65 +25,11 @@ entries:
     archived: true
     description: 基于 Playwright 和AI实现的闲鱼多任务实时/定时监控与智能分析系统，配备了功能完善的后台管理UI。帮助用户从闲鱼海量商品中，找到心仪产品。
     license_spdx: MIT
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-05-18T10:52:34Z'
   content_lock:
     locked_ref: f85d140b6b45029d9a0925feb96dad733b41396d
     locked_url: https://github.com/Usagi-org/ai-goofish-monitor/commit/f85d140b6b45029d9a0925feb96dad733b41396d
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
-- universe: product-lab
-  repo: zinan92/tokenpulse
-  owned: true
-  starred: false
-  source_kind: owned
-  registry_repo: false
-  registry_role: null
-  primary_category: codex-harness
-  tags:
-  - archived
-  - python
-  source_url: https://github.com/zinan92/tokenpulse
-  visibility: public
-  archived: true
-  description: 把 Claude/Codex 本地 token 日志变成桌面鞭策 widget、Telegram 推送、CLI 状态和可分享 QR 战绩卡。in 本地日志 + models.dev → out goad widget
-    + share card
-  status: EXPLORING
-  review_status: confirmed
-  review_reason: null
-  github_snapshot:
-    default_branch: main
-    visibility: public
-    archived: true
-    description: 把 Claude/Codex 本地 token 日志变成桌面鞭策 widget、Telegram 推送、CLI 状态和可分享 QR 战绩卡。in 本地日志 + models.dev → out goad widget
-      + share card
-    license_spdx: NOASSERTION
-    checked_at: 2026-08-27-content-review-01
-    pushed_at: '2026-07-28T16:01:13Z'
-- universe: product-lab
-  repo: zinan92/tokenrouter
-  owned: true
-  starred: false
-  source_kind: owned
-  registry_repo: false
-  registry_role: null
-  primary_category: codex-harness
-  tags:
-  - archived
-  - python
-  source_url: https://github.com/zinan92/tokenrouter
-  visibility: public
-  archived: true
-  description: 个人项目组合工作台：双通道成本账本 + TokenRouter v0 级联内核
-  status: EXPLORING
-  review_status: confirmed
-  review_reason: null
-  github_snapshot:
-    default_branch: main
-    visibility: public
-    archived: true
-    description: 个人项目组合工作台：双通道成本账本 + TokenRouter v0 级联内核
-    license_spdx: NOASSERTION
-    checked_at: 2026-08-27-content-review-01
-    pushed_at: '2026-08-02T08:59:59Z'

--- a/entries/owned.yaml
+++ b/entries/owned.yaml
@@ -1,4 +1,4 @@
-snapshot_id: github-universe-2026-08-27-content-review-01
+snapshot_id: github-universe-2026-08-27-product-park-review-01
 entries:
 - universe: product-lab
   repo: zinan92/codex-harness
@@ -23,7 +23,7 @@ entries:
     archived: false
     description: 本地记录 Codex thread 的 token 使用与项目归属。in Codex session JSONL → out daily thread ledger + read-only HTML UI
     license_spdx: MIT
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-08-04T06:20:07Z'
 - universe: product-lab
   repo: zinan92/life-kline
@@ -49,7 +49,7 @@ entries:
     archived: false
     description: ''
     license_spdx: NOASSERTION
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-07-22T08:47:55Z'
 - universe: product-lab
   repo: zinan92/paileggemai
@@ -75,7 +75,7 @@ entries:
     archived: false
     description: 电商商品图生成短视频工作台
     license_spdx: NOASSERTION
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-07-22T12:23:24Z'
 - universe: product-lab
   repo: zinan92/wechat-customer-pipeline
@@ -102,7 +102,7 @@ entries:
     archived: false
     description: 把授权的本机微信数据库转成私有客户管道与关系行动快照。in WeChat 数据 + 迁移确认 → out HTML + CSV + A/B/C/D + actions + receipts
     license_spdx: NOASSERTION
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-08-07T10:11:39Z'
 - universe: product-lab
   repo: zinan92/wechat-xingqiu
@@ -128,5 +128,5 @@ entries:
     archived: false
     description: wechat-xingqiu：原生微信会员内容小程序
     license_spdx: NOASSERTION
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-08-24T18:24:36Z'

--- a/entries/starred.yaml
+++ b/entries/starred.yaml
@@ -1,4 +1,4 @@
-snapshot_id: github-universe-2026-08-27-content-review-01
+snapshot_id: github-universe-2026-08-27-product-park-review-01
 entries:
 - universe: product-lab
   repo: 6tail/tyme4ts
@@ -23,12 +23,12 @@ entries:
     archived: false
     description: Tyme是一个非常强大的日历工具库，可以看作 Lunar 的升级版，拥有更优的设计和扩展性，支持公历、农历、藏历、回历、星座、干支、生肖、节气、月相、法定假日等。
     license_spdx: MIT
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-08-17T09:47:13Z'
   content_lock:
     locked_ref: 9e776099e164c43fd932684875057fe345773241
     locked_url: https://github.com/6tail/tyme4ts/commit/9e776099e164c43fd932684875057fe345773241
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -56,12 +56,12 @@ entries:
     archived: false
     description: 八字、紫微、星盘、六爻、梅花、奇门、大六壬、小六壬、塔罗、雷诺曼、灵签、择日一站式玄学算命占卜工具包，输出结构化提示词与数据。提供公开 API、MCP Server 与 skill。
     license_spdx: NOASSERTION
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-08-25T12:30:06Z'
   content_lock:
     locked_ref: 1272aa0cd83a802e78b61568571f709517a1e369
     locked_url: https://github.com/Brhiza/mingyu/commit/1272aa0cd83a802e78b61568571f709517a1e369
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -87,12 +87,12 @@ entries:
     archived: false
     description: A benchmark for evaluating LLMs on Chinese traditional fortune telling — Bazi (八字) and Ziwei Doushu (紫微斗数).
     license_spdx: MIT
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-05-09T17:49:34Z'
   content_lock:
     locked_ref: b7433280fd86d7a7c27debbc47d0303c218f0bfd
     locked_url: https://github.com/DestinyLinker/MingLi-Bench/commit/b7433280fd86d7a7c27debbc47d0303c218f0bfd
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -118,12 +118,12 @@ entries:
     archived: false
     description: yinyuan-skills
     license_spdx: NOASSERTION
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-04-05T08:09:38Z'
   content_lock:
     locked_ref: b091c8861a148b8260dedfbd06fc10daf7f886fc
     locked_url: https://github.com/Ming-H/yinyuan-skills/commit/b091c8861a148b8260dedfbd06fc10daf7f886fc
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -149,12 +149,12 @@ entries:
     archived: false
     description: 紫微斗数开源排盘引擎 — 基于倪海夏《天纪》体系，含完整排盘算法、四化系统、格局知识库、古籍原文数据
     license_spdx: MIT
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-06-24T07:24:36Z'
   content_lock:
     locked_ref: 88194a404242bfe5c6d5cc512e4117e3e245cdd5
     locked_url: https://github.com/Renhuai123/ziwei-doushu/commit/88194a404242bfe5c6d5cc512e4117e3e245cdd5
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -183,12 +183,12 @@ entries:
     description: ⭐This is a lightweight kit for generating astrolabes for Zi Wei Dou Shu (The Purple Star Astrology), an ancient
       Chinese astrology. It allows you to obtain your horoscope and personality analysis. 支持多语言轻量级获取紫微斗数排盘信息的javascript开源库。
     license_spdx: MIT
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-08-27T02:18:23Z'
   content_lock:
     locked_ref: 814b77e6371e1050cac31bbf674db3c3138fcfde
     locked_url: https://github.com/SylarLong/iztro/commit/814b77e6371e1050cac31bbf674db3c3138fcfde
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -215,12 +215,12 @@ entries:
     archived: false
     description: Open Multi-Agent Interactive Classroom — Get an immersive, multi-agent learning experience in just one click
     license_spdx: MIT
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-08-27T02:47:15Z'
   content_lock:
     locked_ref: 1b4a168175e88057c77869196f7da8ef657fcb2f
     locked_url: https://github.com/THU-MAIC/OpenMAIC/commit/1b4a168175e88057c77869196f7da8ef657fcb2f
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -247,12 +247,12 @@ entries:
     archived: false
     description: 微信聊天记录skill
     license_spdx: NOASSERTION
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-02-14T08:51:02Z'
   content_lock:
     locked_ref: 6280e9c106a2549340bf750ccae71f4053ed4710
     locked_url: https://github.com/afumu/wetrace-skill/commit/6280e9c106a2549340bf750ccae71f4053ed4710
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -277,12 +277,12 @@ entries:
     archived: false
     description: 人生K线 - 基于AI的八字命理可视化工具
     license_spdx: NOASSERTION
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2025-12-14T13:09:01Z'
   content_lock:
     locked_ref: b9a27a71260a09f26a1e3757fbee2ba71f52773b
     locked_url: https://github.com/curionox/lifekline/commit/b9a27a71260a09f26a1e3757fbee2ba71f52773b
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -308,12 +308,12 @@ entries:
     archived: false
     description: Obsidian + Claude AI 个人知识库完整搭建指南 | 基于 Karpathy LLM Wiki 方法论 | 4 阶段 12 步 | 不用写代码
     license_spdx: MIT
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-04-13T09:34:10Z'
   content_lock:
     locked_ref: fb3468a1d5facf6f42bcce4db4d161dabd1fd615
     locked_url: https://github.com/helloianneo/obsidian-ai-second-brain/commit/fb3468a1d5facf6f42bcce4db4d161dabd1fd615
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -340,12 +340,12 @@ entries:
     archived: false
     description: 紫微斗数命盘解读 skill · 基于 iztro-py 精确排盘，生成可视化命盘 HTML
     license_spdx: MIT
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-08-15T12:51:17Z'
   content_lock:
     locked_ref: 000da99552cdfdbdfde49f6e76b014515b8ea51c
     locked_url: https://github.com/learnwithu/mingli-master/commit/000da99552cdfdbdfde49f6e76b014515b8ea51c
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -371,11 +371,11 @@ entries:
     archived: false
     description: 🌟 人生K线 - 基于 AI 大模型 + 传统八字命理的人生运势可视化工具。将命运绘制成 K 线图，像看股票一样看人生！支持自托管部署。
     license_spdx: Apache-2.0
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2025-12-22T09:41:30Z'
   content_lock:
     locked_ref: 7abf184df370452ee8279d72c8b45bc09e19913b
     locked_url: https://github.com/miounet11/life-kline/commit/7abf184df370452ee8279d72c8b45bc09e19913b
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false

--- a/locks/sources.lock.yaml
+++ b/locks/sources.lock.yaml
@@ -1,12 +1,12 @@
-snapshot_id: github-universe-2026-08-27-content-review-01
-generated_from_checksum: 717878249f70f990cc4c5abba5f5fc2957fa253ad19a76208ca4ab7891e0bbe1
+snapshot_id: github-universe-2026-08-27-product-park-review-01
+generated_from_checksum: 1e9b753d0fdfdd43fbc9297acdb7a06ccbdc06894f23502b38dc6d3bb7193c99
 locks:
 - repo: 6tail/tyme4ts
   source_url: https://github.com/6tail/tyme4ts
   content_lock:
     locked_ref: 9e776099e164c43fd932684875057fe345773241
     locked_url: https://github.com/6tail/tyme4ts/commit/9e776099e164c43fd932684875057fe345773241
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: Brhiza/mingyu
@@ -14,7 +14,7 @@ locks:
   content_lock:
     locked_ref: 1272aa0cd83a802e78b61568571f709517a1e369
     locked_url: https://github.com/Brhiza/mingyu/commit/1272aa0cd83a802e78b61568571f709517a1e369
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: DestinyLinker/MingLi-Bench
@@ -22,7 +22,7 @@ locks:
   content_lock:
     locked_ref: b7433280fd86d7a7c27debbc47d0303c218f0bfd
     locked_url: https://github.com/DestinyLinker/MingLi-Bench/commit/b7433280fd86d7a7c27debbc47d0303c218f0bfd
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: Ming-H/yinyuan-skills
@@ -30,7 +30,7 @@ locks:
   content_lock:
     locked_ref: b091c8861a148b8260dedfbd06fc10daf7f886fc
     locked_url: https://github.com/Ming-H/yinyuan-skills/commit/b091c8861a148b8260dedfbd06fc10daf7f886fc
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: Renhuai123/ziwei-doushu
@@ -38,7 +38,7 @@ locks:
   content_lock:
     locked_ref: 88194a404242bfe5c6d5cc512e4117e3e245cdd5
     locked_url: https://github.com/Renhuai123/ziwei-doushu/commit/88194a404242bfe5c6d5cc512e4117e3e245cdd5
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: SylarLong/iztro
@@ -46,7 +46,7 @@ locks:
   content_lock:
     locked_ref: 814b77e6371e1050cac31bbf674db3c3138fcfde
     locked_url: https://github.com/SylarLong/iztro/commit/814b77e6371e1050cac31bbf674db3c3138fcfde
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: THU-MAIC/OpenMAIC
@@ -54,7 +54,7 @@ locks:
   content_lock:
     locked_ref: 1b4a168175e88057c77869196f7da8ef657fcb2f
     locked_url: https://github.com/THU-MAIC/OpenMAIC/commit/1b4a168175e88057c77869196f7da8ef657fcb2f
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: Usagi-org/ai-goofish-monitor
@@ -62,7 +62,7 @@ locks:
   content_lock:
     locked_ref: f85d140b6b45029d9a0925feb96dad733b41396d
     locked_url: https://github.com/Usagi-org/ai-goofish-monitor/commit/f85d140b6b45029d9a0925feb96dad733b41396d
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: afumu/wetrace-skill
@@ -70,7 +70,7 @@ locks:
   content_lock:
     locked_ref: 6280e9c106a2549340bf750ccae71f4053ed4710
     locked_url: https://github.com/afumu/wetrace-skill/commit/6280e9c106a2549340bf750ccae71f4053ed4710
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: curionox/lifekline
@@ -78,7 +78,7 @@ locks:
   content_lock:
     locked_ref: b9a27a71260a09f26a1e3757fbee2ba71f52773b
     locked_url: https://github.com/curionox/lifekline/commit/b9a27a71260a09f26a1e3757fbee2ba71f52773b
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: helloianneo/obsidian-ai-second-brain
@@ -86,7 +86,7 @@ locks:
   content_lock:
     locked_ref: fb3468a1d5facf6f42bcce4db4d161dabd1fd615
     locked_url: https://github.com/helloianneo/obsidian-ai-second-brain/commit/fb3468a1d5facf6f42bcce4db4d161dabd1fd615
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: learnwithu/mingli-master
@@ -94,7 +94,7 @@ locks:
   content_lock:
     locked_ref: 000da99552cdfdbdfde49f6e76b014515b8ea51c
     locked_url: https://github.com/learnwithu/mingli-master/commit/000da99552cdfdbdfde49f6e76b014515b8ea51c
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - repo: miounet11/life-kline
@@ -102,6 +102,6 @@ locks:
   content_lock:
     locked_ref: 7abf184df370452ee8279d72c8b45bc09e19913b
     locked_url: https://github.com/miounet11/life-kline/commit/7abf184df370452ee8279d72c8b45bc09e19913b
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false

--- a/registry.yaml
+++ b/registry.yaml
@@ -2,6 +2,6 @@ universe: product-lab
 registry_repo: true
 registry_role: public_scoped
 canonical_registry_repo: zinan92/park-operating-system
-canonical_snapshot: github-universe-2026-08-27-content-review-01
-generated_from_checksum: 717878249f70f990cc4c5abba5f5fc2957fa253ad19a76208ca4ab7891e0bbe1
-export_checksum: 823ee8bc7e9afdda253cc2e3c0567f88168323d569adfb8bb7f3bcdd829411c1
+canonical_snapshot: github-universe-2026-08-27-product-park-review-01
+generated_from_checksum: 1e9b753d0fdfdd43fbc9297acdb7a06ccbdc06894f23502b38dc6d3bb7193c99
+export_checksum: 5673c66989846c797b3e7af027126186cb622c8df2ccd93c2487c6e3df67725b

--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -1,7 +1,7 @@
 universe: product-lab
-snapshot_id: github-universe-2026-08-27-content-review-01
+snapshot_id: github-universe-2026-08-27-product-park-review-01
 generated_from: zinan92/park-operating-system
-generated_from_checksum: 717878249f70f990cc4c5abba5f5fc2957fa253ad19a76208ca4ab7891e0bbe1
+generated_from_checksum: 1e9b753d0fdfdd43fbc9297acdb7a06ccbdc06894f23502b38dc6d3bb7193c99
 entries:
 - universe: product-lab
   repo: 6tail/tyme4ts
@@ -26,12 +26,12 @@ entries:
     archived: false
     description: Tyme是一个非常强大的日历工具库，可以看作 Lunar 的升级版，拥有更优的设计和扩展性，支持公历、农历、藏历、回历、星座、干支、生肖、节气、月相、法定假日等。
     license_spdx: MIT
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-08-17T09:47:13Z'
   content_lock:
     locked_ref: 9e776099e164c43fd932684875057fe345773241
     locked_url: https://github.com/6tail/tyme4ts/commit/9e776099e164c43fd932684875057fe345773241
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -59,12 +59,12 @@ entries:
     archived: false
     description: 八字、紫微、星盘、六爻、梅花、奇门、大六壬、小六壬、塔罗、雷诺曼、灵签、择日一站式玄学算命占卜工具包，输出结构化提示词与数据。提供公开 API、MCP Server 与 skill。
     license_spdx: NOASSERTION
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-08-25T12:30:06Z'
   content_lock:
     locked_ref: 1272aa0cd83a802e78b61568571f709517a1e369
     locked_url: https://github.com/Brhiza/mingyu/commit/1272aa0cd83a802e78b61568571f709517a1e369
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -90,12 +90,12 @@ entries:
     archived: false
     description: A benchmark for evaluating LLMs on Chinese traditional fortune telling — Bazi (八字) and Ziwei Doushu (紫微斗数).
     license_spdx: MIT
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-05-09T17:49:34Z'
   content_lock:
     locked_ref: b7433280fd86d7a7c27debbc47d0303c218f0bfd
     locked_url: https://github.com/DestinyLinker/MingLi-Bench/commit/b7433280fd86d7a7c27debbc47d0303c218f0bfd
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -121,12 +121,12 @@ entries:
     archived: false
     description: yinyuan-skills
     license_spdx: NOASSERTION
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-04-05T08:09:38Z'
   content_lock:
     locked_ref: b091c8861a148b8260dedfbd06fc10daf7f886fc
     locked_url: https://github.com/Ming-H/yinyuan-skills/commit/b091c8861a148b8260dedfbd06fc10daf7f886fc
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -152,12 +152,12 @@ entries:
     archived: false
     description: 紫微斗数开源排盘引擎 — 基于倪海夏《天纪》体系，含完整排盘算法、四化系统、格局知识库、古籍原文数据
     license_spdx: MIT
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-06-24T07:24:36Z'
   content_lock:
     locked_ref: 88194a404242bfe5c6d5cc512e4117e3e245cdd5
     locked_url: https://github.com/Renhuai123/ziwei-doushu/commit/88194a404242bfe5c6d5cc512e4117e3e245cdd5
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -186,12 +186,12 @@ entries:
     description: ⭐This is a lightweight kit for generating astrolabes for Zi Wei Dou Shu (The Purple Star Astrology), an ancient
       Chinese astrology. It allows you to obtain your horoscope and personality analysis. 支持多语言轻量级获取紫微斗数排盘信息的javascript开源库。
     license_spdx: MIT
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-08-27T02:18:23Z'
   content_lock:
     locked_ref: 814b77e6371e1050cac31bbf674db3c3138fcfde
     locked_url: https://github.com/SylarLong/iztro/commit/814b77e6371e1050cac31bbf674db3c3138fcfde
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -218,12 +218,12 @@ entries:
     archived: false
     description: Open Multi-Agent Interactive Classroom — Get an immersive, multi-agent learning experience in just one click
     license_spdx: MIT
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-08-27T02:47:15Z'
   content_lock:
     locked_ref: 1b4a168175e88057c77869196f7da8ef657fcb2f
     locked_url: https://github.com/THU-MAIC/OpenMAIC/commit/1b4a168175e88057c77869196f7da8ef657fcb2f
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -251,12 +251,12 @@ entries:
     archived: true
     description: 基于 Playwright 和AI实现的闲鱼多任务实时/定时监控与智能分析系统，配备了功能完善的后台管理UI。帮助用户从闲鱼海量商品中，找到心仪产品。
     license_spdx: MIT
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-05-18T10:52:34Z'
   content_lock:
     locked_ref: f85d140b6b45029d9a0925feb96dad733b41396d
     locked_url: https://github.com/Usagi-org/ai-goofish-monitor/commit/f85d140b6b45029d9a0925feb96dad733b41396d
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -283,12 +283,12 @@ entries:
     archived: false
     description: 微信聊天记录skill
     license_spdx: NOASSERTION
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-02-14T08:51:02Z'
   content_lock:
     locked_ref: 6280e9c106a2549340bf750ccae71f4053ed4710
     locked_url: https://github.com/afumu/wetrace-skill/commit/6280e9c106a2549340bf750ccae71f4053ed4710
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -313,12 +313,12 @@ entries:
     archived: false
     description: 人生K线 - 基于AI的八字命理可视化工具
     license_spdx: NOASSERTION
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2025-12-14T13:09:01Z'
   content_lock:
     locked_ref: b9a27a71260a09f26a1e3757fbee2ba71f52773b
     locked_url: https://github.com/curionox/lifekline/commit/b9a27a71260a09f26a1e3757fbee2ba71f52773b
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -344,12 +344,12 @@ entries:
     archived: false
     description: Obsidian + Claude AI 个人知识库完整搭建指南 | 基于 Karpathy LLM Wiki 方法论 | 4 阶段 12 步 | 不用写代码
     license_spdx: MIT
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-04-13T09:34:10Z'
   content_lock:
     locked_ref: fb3468a1d5facf6f42bcce4db4d161dabd1fd615
     locked_url: https://github.com/helloianneo/obsidian-ai-second-brain/commit/fb3468a1d5facf6f42bcce4db4d161dabd1fd615
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -376,12 +376,12 @@ entries:
     archived: false
     description: 紫微斗数命盘解读 skill · 基于 iztro-py 精确排盘，生成可视化命盘 HTML
     license_spdx: MIT
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-08-15T12:51:17Z'
   content_lock:
     locked_ref: 000da99552cdfdbdfde49f6e76b014515b8ea51c
     locked_url: https://github.com/learnwithu/mingli-master/commit/000da99552cdfdbdfde49f6e76b014515b8ea51c
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -407,12 +407,12 @@ entries:
     archived: false
     description: 🌟 人生K线 - 基于 AI 大模型 + 传统八字命理的人生运势可视化工具。将命运绘制成 K 线图，像看股票一样看人生！支持自托管部署。
     license_spdx: Apache-2.0
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2025-12-22T09:41:30Z'
   content_lock:
     locked_ref: 7abf184df370452ee8279d72c8b45bc09e19913b
     locked_url: https://github.com/miounet11/life-kline/commit/7abf184df370452ee8279d72c8b45bc09e19913b
-    locked_at: 2026-08-27-content-review-01
+    locked_at: 2026-08-27-product-park-review-01
     update_policy: monthly_pr
     vendored: false
 - universe: product-lab
@@ -438,7 +438,7 @@ entries:
     archived: false
     description: 本地记录 Codex thread 的 token 使用与项目归属。in Codex session JSONL → out daily thread ledger + read-only HTML UI
     license_spdx: MIT
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-08-04T06:20:07Z'
 - universe: product-lab
   repo: zinan92/life-kline
@@ -464,7 +464,7 @@ entries:
     archived: false
     description: ''
     license_spdx: NOASSERTION
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-07-22T08:47:55Z'
 - universe: product-lab
   repo: zinan92/paileggemai
@@ -490,62 +490,8 @@ entries:
     archived: false
     description: 电商商品图生成短视频工作台
     license_spdx: NOASSERTION
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-07-22T12:23:24Z'
-- universe: product-lab
-  repo: zinan92/tokenpulse
-  owned: true
-  starred: false
-  source_kind: owned
-  registry_repo: false
-  registry_role: null
-  primary_category: codex-harness
-  tags:
-  - archived
-  - python
-  source_url: https://github.com/zinan92/tokenpulse
-  visibility: public
-  archived: true
-  description: 把 Claude/Codex 本地 token 日志变成桌面鞭策 widget、Telegram 推送、CLI 状态和可分享 QR 战绩卡。in 本地日志 + models.dev → out goad widget
-    + share card
-  status: EXPLORING
-  review_status: confirmed
-  review_reason: null
-  github_snapshot:
-    default_branch: main
-    visibility: public
-    archived: true
-    description: 把 Claude/Codex 本地 token 日志变成桌面鞭策 widget、Telegram 推送、CLI 状态和可分享 QR 战绩卡。in 本地日志 + models.dev → out goad widget
-      + share card
-    license_spdx: NOASSERTION
-    checked_at: 2026-08-27-content-review-01
-    pushed_at: '2026-07-28T16:01:13Z'
-- universe: product-lab
-  repo: zinan92/tokenrouter
-  owned: true
-  starred: false
-  source_kind: owned
-  registry_repo: false
-  registry_role: null
-  primary_category: codex-harness
-  tags:
-  - archived
-  - python
-  source_url: https://github.com/zinan92/tokenrouter
-  visibility: public
-  archived: true
-  description: 个人项目组合工作台：双通道成本账本 + TokenRouter v0 级联内核
-  status: EXPLORING
-  review_status: confirmed
-  review_reason: null
-  github_snapshot:
-    default_branch: main
-    visibility: public
-    archived: true
-    description: 个人项目组合工作台：双通道成本账本 + TokenRouter v0 级联内核
-    license_spdx: NOASSERTION
-    checked_at: 2026-08-27-content-review-01
-    pushed_at: '2026-08-02T08:59:59Z'
 - universe: product-lab
   repo: zinan92/wechat-customer-pipeline
   owned: true
@@ -571,7 +517,7 @@ entries:
     archived: false
     description: 把授权的本机微信数据库转成私有客户管道与关系行动快照。in WeChat 数据 + 迁移确认 → out HTML + CSV + A/B/C/D + actions + receipts
     license_spdx: NOASSERTION
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-08-07T10:11:39Z'
 - universe: product-lab
   repo: zinan92/wechat-xingqiu
@@ -597,6 +543,6 @@ entries:
     archived: false
     description: wechat-xingqiu：原生微信会员内容小程序
     license_spdx: NOASSERTION
-    checked_at: 2026-08-27-content-review-01
+    checked_at: 2026-08-27-product-park-review-01
     pushed_at: '2026-08-24T18:24:36Z'
-export_checksum: 823ee8bc7e9afdda253cc2e3c0567f88168323d569adfb8bb7f3bcdd829411c1
+export_checksum: 5673c66989846c797b3e7af027126186cb622c8df2ccd93c2487c6e3df67725b


### PR DESCRIPTION
Apply the completed Product Lab decision by excluding `zinan92/tokenrouter` and `zinan92/tokenpulse` from the active catalog while preserving the removal history.

Validation: `bash scripts/verify-scoped.sh` PASS (18 entries); `git diff --check` PASS; gitleaks PASS.
Canonical: https://github.com/zinan92/park-operating-system/issues/89